### PR TITLE
feat: configurable default-profile mode for Comet MCP

### DIFF
--- a/.claude/WORKFLOW.md
+++ b/.claude/WORKFLOW.md
@@ -1,0 +1,41 @@
+# Workflow Guidance
+
+## Default record of work
+- Prefer GitHub issues for task records, acceptance criteria, implementation notes, and progress updates.
+- Link code changes to an issue when possible. For this workflow redesign, use issue #30 as the parent record unless a narrower issue exists.
+- Prefer finishing work as a PR, not as an untracked local change set.
+
+## When to use local markdown plans
+- Use local markdown plans only for larger architectural work that does not fit cleanly in a single GitHub issue.
+- Keep local plans scoped to design/architecture. Day-to-day task tracking should stay in GitHub.
+- If a local plan exists, link it back to the relevant GitHub issue or PR.
+
+## Working modes
+
+### Interactive mode
+Use this for normal request/response work with a human reviewing changes live.
+- Confirm assumptions before non-trivial changes.
+- Keep changes surgical and easy to review.
+- Record acceptance criteria and progress in the linked GitHub issue or PR.
+
+### Ralph-loop mode
+Use this for tighter autonomous iteration loops when the task has already been framed.
+- Start from a clear issue or other written task record.
+- Keep each loop pointed at a concrete success condition.
+- Post meaningful progress back to GitHub so the loop does not become local-only state.
+- Escalate back to interactive mode when requirements are unclear or conflicting.
+
+## Verification expectations
+- Backend-only changes: use the smallest targeted CLI verification that proves the change works.
+- UI-affecting changes: run Playwright flows that cover the changed behavior.
+- For UI work, save screenshots and note:
+  - what was tested
+  - which flow was exercised
+  - where screenshots were saved
+- Verification notes belong in the PR and, when useful, in the linked issue.
+
+## GitHub-first execution
+- Prefer GitHub MCP for issue, PR, review, comment, and status operations when available.
+- Keep issue and PR threads as the primary collaboration log.
+- Prefer reviewable PR-sized slices of work over large local batches.
+- When a task is complete, leave the repo in a PR-ready state with clear verification notes.

--- a/.claude/skills/issue-driven-task/SKILL.md
+++ b/.claude/skills/issue-driven-task/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: issue-driven-task
+description: Use GitHub issues as the default task record before implementing non-trivial work. Trigger this whenever work should be tracked visibly, when roadmap items need to become executable tasks, or when you would otherwise create a local markdown plan that could fit in an issue instead.
+---
+
+# Issue-Driven Task
+
+Default to GitHub issues for scoped work.
+
+## When to use local markdown instead
+Use a local design or plan document only when the work is architectural enough that the issue body cannot hold the necessary context cleanly.
+
+## Workflow
+1. Check whether a relevant GitHub issue already exists.
+2. If none exists and GitHub MCP is available, create a focused issue with:
+   - scope
+   - acceptance criteria
+   - any constraints that matter
+3. Use the issue as the main execution record.
+4. Keep progress visible in GitHub rather than storing the working state only in local markdown.
+5. Finish in a PR-oriented state when appropriate.
+
+## Reporting expectations
+Before claiming completion, summarize:
+- which issue the work belongs to
+- what changed
+- what verification ran
+- what still remains

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ coverage/
 
 # Claude Code
 .claude/
+.worktrees/

--- a/src/cdp-client.ts
+++ b/src/cdp-client.ts
@@ -2,9 +2,10 @@
 // Modified for Windows/WSL support
 
 import CDP from "chrome-remote-interface";
-import { spawn, ChildProcess, execSync } from "child_process";
-import { platform } from "os";
+import { spawn, ChildProcess, execSync, execFileSync } from "child_process";
+import { platform, homedir } from "os";
 import { existsSync } from "fs";
+import path from "path";
 import type {
   CDPTarget,
   CDPVersion,
@@ -143,7 +144,91 @@ function getCometPath(): string {
 
 const COMET_PATH = getCometPath();
 const IS_WINDOWS = platform() === "win32" || IS_WSL;
-const DEFAULT_PORT = 9223;
+const DEFAULT_PORT = Number.parseInt(process.env.COMET_PORT || "9223", 10) || 9223;
+const DEFAULT_AUTOMATION_PROFILE = "ClaudeAutomation";
+
+type ProfileMode = 'isolated' | 'default';
+
+function getProfileMode(): ProfileMode {
+  return process.env.COMET_PROFILE_MODE === 'default' ? 'default' : 'isolated';
+}
+
+function getProfileModeLabel(): string {
+  return getProfileMode() === 'default' ? 'default-profile' : 'isolated';
+}
+
+function getDefaultAutomationUserDataDir(): string {
+  if (platform() === "darwin") {
+    return path.join(homedir(), "Library", "Application Support", "Perplexity", "Comet-Claude-Automation");
+  }
+
+  if (platform() === "win32" || IS_WSL) {
+    const localAppData = process.env.LOCALAPPDATA || path.join(homedir(), "AppData", "Local");
+    return path.join(localAppData, "Perplexity", "Comet", "ClaudeAutomation");
+  }
+
+  return path.join(homedir(), ".config", "perplexity-comet-claude-automation");
+}
+
+function getDefaultProfileUserDataDir(): string {
+  if (platform() === "darwin") {
+    return path.join(homedir(), "Library", "Application Support", "Perplexity", "Comet", "User Data");
+  }
+
+  if (platform() === "win32" || IS_WSL) {
+    const localAppData = process.env.LOCALAPPDATA || path.join(homedir(), "AppData", "Local");
+    return path.join(localAppData, "Perplexity", "Comet", "User Data");
+  }
+
+  return path.join(homedir(), ".config", "Perplexity", "Comet", "User Data");
+}
+
+function getDefaultProfileDir(): string {
+  return "Default";
+}
+
+function getAutomationUserDataDir(): string {
+  if (getProfileMode() === 'default') {
+    return getDefaultProfileUserDataDir();
+  }
+
+  return process.env.COMET_USER_DATA_DIR || getDefaultAutomationUserDataDir();
+}
+
+function getAutomationProfileDir(): string {
+  if (getProfileMode() === 'default') {
+    return getDefaultProfileDir();
+  }
+
+  return process.env.COMET_PROFILE_DIR || DEFAULT_AUTOMATION_PROFILE;
+}
+
+function getCometLaunchArgs(port: number, restoreSession: boolean = false): string[] {
+  if (getProfileMode() === 'default') {
+    // Default-profile mode: no user-data-dir/profile-directory so we use the user's logged-in profile.
+    // When restarting an existing Comet, --restore-last-session preserves open tabs.
+    const args = [
+      `--remote-debugging-port=${port}`,
+      "--new-window",
+    ];
+    if (restoreSession) {
+      args.push("--restore-last-session");
+    }
+    return args;
+  }
+
+  // Isolated mode: separate profile directory for automation
+  return [
+    `--remote-debugging-port=${port}`,
+    `--user-data-dir=${getAutomationUserDataDir()}`,
+    `--profile-directory=${getAutomationProfileDir()}`,
+    "--new-window",
+  ];
+}
+
+function formatAutomationDescriptor(port: number): string {
+  return `mode=${getProfileModeLabel()} port=${port} profile=${getAutomationProfileDir()} userDataDir=${getAutomationUserDataDir()}`;
+}
 
 export class CometCDPClient {
   private client: CDP.Client | null = null;
@@ -152,7 +237,12 @@ export class CometCDPClient {
     connected: false,
     port: DEFAULT_PORT,
   };
+  private automationMainTabId: string | undefined;
   private lastTargetId: string | undefined;
+
+  private isPerplexityUrl(url: string | undefined): boolean {
+    return Boolean(url && url.includes('perplexity.ai'));
+  }
   private reconnectAttempts: number = 0;
   private maxReconnectAttempts: number = 10;
   private isReconnecting: boolean = false;
@@ -163,6 +253,8 @@ export class CometCDPClient {
 
   // Tab context registry for multi-tab workflow awareness
   private tabRegistry: Map<string, TabContext> = new Map();
+  // Tabs that existed before the MCP session started (pre-existing user tabs)
+  private baselineTabIds: Set<string> = new Set();
 
   get isConnected(): boolean {
     return this.state.connected && this.client !== null;
@@ -328,7 +420,6 @@ export class CometCDPClient {
     this.state.connected = false;
     this.client = null;
 
-    // Verify Comet is running
     try {
       await this.getVersion();
     } catch {
@@ -336,11 +427,10 @@ export class CometCDPClient {
         await this.startComet(this.state.port);
         await new Promise(resolve => setTimeout(resolve, 2000));
       } catch {
-        throw new Error('Cannot connect to Comet. Ensure Comet is running with --remote-debugging-port=9222');
+        throw new Error(`Cannot connect to Comet automation on debug port ${this.state.port}`);
       }
     }
 
-    // Try to reconnect to last target
     if (this.lastTargetId) {
       try {
         const targets = await this.listTargets();
@@ -350,16 +440,29 @@ export class CometCDPClient {
       } catch { /* target gone */ }
     }
 
-    // Find best target
-    const targets = await this.listTargets();
-    const target = targets.find(t => t.type === 'page' && t.url.includes('perplexity.ai')) ||
-                   targets.find(t => t.type === 'page' && t.url !== 'about:blank');
-
-    if (target) {
-      return await this.connect(target.id);
+    if (this.automationMainTabId) {
+      try {
+        const targets = await this.listTargets();
+        if (targets.find(t => t.id === this.automationMainTabId)) {
+          return await this.connect(this.automationMainTabId);
+        }
+      } catch { /* target gone */ }
     }
 
-    throw new Error('No suitable tab found for reconnection');
+    const targets = await this.listTargets();
+    const pageTargets = targets.filter(t => t.type === 'page');
+    const activeTarget = pageTargets.find(t => t.id === this.state.activeTabId);
+    if (activeTarget) {
+      return await this.connect(activeTarget.id);
+    }
+
+    const nonInternalTarget = pageTargets.find(t => !this.isInternalTab(t.url));
+    if (nonInternalTarget) {
+      return await this.connect(nonInternalTarget.id);
+    }
+
+    const target = await this.ensureAutomationPerplexityTab();
+    return `Connected to tab: ${target.url}`;
   }
 
   /**
@@ -373,31 +476,310 @@ export class CometCDPClient {
     others: CDPTarget[];
   }> {
     const targets = await this.listTargets();
+    const pageTargets = targets.filter(t => t.type === 'page');
+    const mainTarget = this.automationMainTabId
+      ? pageTargets.find(t => t.id === this.automationMainTabId) || null
+      : null;
+    const scopedMain = mainTarget || pageTargets.find(t =>
+      this.isPerplexityUrl(t.url) && !t.url.includes('sidecar')
+    ) || null;
 
     return {
-      main: targets.find(t =>
-        t.type === 'page' && t.url.includes('perplexity.ai') && !t.url.includes('sidecar')
+      main: scopedMain,
+      sidecar: pageTargets.find(t =>
+        t.url.includes('sidecar')
       ) || null,
-      sidecar: targets.find(t =>
-        t.type === 'page' && t.url.includes('sidecar')
-      ) || null,
-      agentBrowsing: targets.find(t =>
-        t.type === 'page' &&
-        !t.url.includes('perplexity.ai') &&
-        !t.url.includes('chrome-extension') &&
-        !t.url.includes('chrome://') &&
-        t.url !== 'about:blank'
+      agentBrowsing: pageTargets.find(t =>
+        t.id !== scopedMain?.id &&
+        !this.isInternalTab(t.url) &&
+        !this.isPerplexityUrl(t.url) &&
+        !this.baselineTabIds.has(t.id) // Only report tabs opened during this session
       ) || null,
       overlay: targets.find(t =>
         t.url.includes('chrome-extension') && t.url.includes('overlay')
       ) || null,
-      others: targets.filter(t =>
-        t.type === 'page' &&
-        !t.url.includes('perplexity.ai') &&
+      others: pageTargets.filter(t =>
+        t.id !== scopedMain?.id &&
         !t.url.includes('chrome-extension')
       ),
     };
   }
+
+  getAutomationConfig(): { port: number; profileMode: string; userDataDir: string; profileDir: string } {
+    return {
+      port: this.state.port,
+      profileMode: getProfileModeLabel(),
+      userDataDir: getAutomationUserDataDir(),
+      profileDir: getAutomationProfileDir(),
+    };
+  }
+
+  private async connectToPort(port: number): Promise<CDP.Client> {
+    const connectPort = await getWSLConnectPort(port);
+    return CDP({ port: connectPort, host: '127.0.0.1' });
+  }
+
+  private async isDebugPortReachable(port: number): Promise<boolean> {
+    try {
+      const client = await this.connectToPort(port);
+      await client.close();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async waitForDebugPort(port: number, startDelayMs: number = 1500): Promise<void> {
+    await new Promise(resolve => setTimeout(resolve, startDelayMs));
+
+    const maxAttempts = 40;
+    for (let attempts = 0; attempts < maxAttempts; attempts++) {
+      if (await this.isDebugPortReachable(port)) {
+        return;
+      }
+      await new Promise(resolve => setTimeout(resolve, 500));
+    }
+
+    throw new Error(`Timeout waiting for Comet on debug port ${port}. Try running: "${COMET_PATH}" ${getCometLaunchArgs(port).join(' ')}`);
+  }
+
+  private getWindowsProcessCommandLines(): string[] {
+    try {
+      const output = execFileSync('powershell.exe', [
+        '-NoProfile',
+        '-Command',
+        'Get-CimInstance Win32_Process | Where-Object { $_.Name -eq "comet.exe" } | Select-Object -ExpandProperty CommandLine'
+      ], {
+        encoding: 'utf8',
+        timeout: 10000,
+        windowsHide: true,
+      });
+
+      return output
+        .split(/\r?\n/)
+        .map(line => line.trim())
+        .filter(Boolean);
+    } catch {
+      return [];
+    }
+  }
+
+  private async isExpectedAutomationInstance(port: number): Promise<boolean> {
+    const portArg = `--remote-debugging-port=${port}`;
+
+    if (IS_WINDOWS) {
+      const commandLines = this.getWindowsProcessCommandLines();
+      return commandLines.some(commandLine => {
+        if (!commandLine.includes(portArg)) {
+          return false;
+        }
+
+        if (getProfileMode() === 'default') {
+          // Default-profile mode: just match on the debug port (no user-data-dir in args)
+          return true;
+        }
+
+        const userDataDirArg = `--user-data-dir=${getAutomationUserDataDir()}`;
+        const profileDirArg = `--profile-directory=${getAutomationProfileDir()}`;
+        return commandLine.includes(userDataDirArg) && commandLine.includes(profileDirArg);
+      });
+    }
+
+    return false;
+  }
+
+  private async getBrowserCommandLine(port: number): Promise<string[] | null> {
+    try {
+      const client = await this.connectToPort(port);
+      try {
+        const result = await (client as any).Browser.getBrowserCommandLine();
+        return Array.isArray(result?.arguments) ? result.arguments : null;
+      } finally {
+        await client.close();
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  private async findRunningAutomationPort(startPort: number): Promise<number | null> {
+    let candidate = startPort;
+    for (let attempts = 0; attempts < 20; attempts++, candidate++) {
+      if (!await this.isDebugPortReachable(candidate)) {
+        continue;
+      }
+
+      if (await this.isExpectedAutomationInstance(candidate)) {
+        return candidate;
+      }
+    }
+
+    return null;
+  }
+
+  private async findAvailableDebugPort(startPort: number): Promise<number> {
+    let candidate = startPort;
+    for (let attempts = 0; attempts < 20; attempts++, candidate++) {
+      if (!await this.isDebugPortReachable(candidate)) {
+        return candidate;
+      }
+    }
+
+    throw new Error(`Could not find an available Comet debug port starting at ${startPort}`);
+  }
+
+  private async launchCometProcess(port: number, restoreSession: boolean = false): Promise<void> {
+    const args = getCometLaunchArgs(port, restoreSession);
+
+    if (IS_WSL) {
+      const cometPath = COMET_PATH;
+      const escapedArgs = args.map(arg => `'${arg.replace(/'/g, "''")}'`).join(', ');
+      const psCommand = `Set-Location C:\\; Start-Process -FilePath '${cometPath.replace(/'/g, "''")}' -ArgumentList @(${escapedArgs})`;
+      spawn('powershell.exe', ['-NoProfile', '-Command', psCommand], {
+        detached: true,
+        stdio: 'ignore',
+      }).unref();
+      return;
+    }
+
+    this.cometProcess = spawn(COMET_PATH, args, {
+      detached: true,
+      stdio: "ignore",
+      shell: true,
+    });
+    this.cometProcess.on('error', (err) => {
+      console.error(`[comet] Failed to launch Comet process: ${err.message}`);
+    });
+    this.cometProcess.unref();
+  }
+
+  async ensureAutomationPerplexityTab(url: string = "https://www.perplexity.ai/"): Promise<CDPTarget> {
+    const targets = await this.listTargets();
+    const pageTargets = targets.filter(t => t.type === 'page');
+
+    let mainTarget: CDPTarget | null = null;
+
+    // If we have a saved main tab, verify it's still a non-sidecar Perplexity page
+    if (this.automationMainTabId) {
+      const saved = pageTargets.find(t => t.id === this.automationMainTabId);
+      if (saved && this.isPerplexityUrl(saved.url) && !saved.url.includes('sidecar')) {
+        mainTarget = saved;
+      }
+    }
+
+    if (!mainTarget) {
+      // Prefer non-sidecar Perplexity pages (the main search page, not the copilot panel)
+      mainTarget = pageTargets.find(t => this.isPerplexityUrl(t.url) && !t.url.includes('sidecar')) || null;
+    }
+
+    if (!mainTarget) {
+      // Open a new Perplexity tab (don't use the sidecar as control tab)
+      console.error(`[comet] No main Perplexity tab found among ${pageTargets.length} pages; opening new tab`);
+      mainTarget = await this.newTab(url);
+      await new Promise(resolve => setTimeout(resolve, 2200));
+    }
+
+    this.automationMainTabId = mainTarget.id;
+    await this.connect(mainTarget.id);
+
+    if (!this.isPerplexityUrl(mainTarget.url)) {
+      await this.navigate(url, true);
+      await new Promise(resolve => setTimeout(resolve, 1800));
+      const refreshedTargets = await this.listTargets();
+      mainTarget = refreshedTargets.find(t => t.id === this.automationMainTabId) || mainTarget;
+    }
+
+    // Record baseline tabs (pre-existing user tabs) on first setup
+    if (this.baselineTabIds.size === 0) {
+      for (const t of pageTargets) {
+        this.baselineTabIds.add(t.id);
+      }
+    }
+
+    this.setTabPurpose(mainTarget.id, 'main');
+    return mainTarget;
+  }
+
+  async connectToAutomationMainTab(): Promise<CDPTarget> {
+    const mainTarget = await this.ensureAutomationPerplexityTab();
+    this.automationMainTabId = mainTarget.id;
+    return mainTarget;
+  }
+
+  async getAutomationMainTab(): Promise<CDPTarget | null> {
+    if (!this.automationMainTabId) {
+      return null;
+    }
+
+    const targets = await this.listTargets();
+    return targets.find(t => t.id === this.automationMainTabId) || null;
+  }
+
+  async connectToLastActiveTab(): Promise<boolean> {
+    const targets = await this.listTargets();
+    const pageTargets = targets.filter(t => t.type === 'page');
+
+    const preferredTarget = [
+      this.lastTargetId,
+      this.state.activeTabId,
+      pageTargets.find(t => !this.isInternalTab(t.url))?.id,
+      this.automationMainTabId,
+    ].filter((id): id is string => Boolean(id)).find(id => pageTargets.some(t => t.id === id));
+
+    if (!preferredTarget) {
+      return false;
+    }
+
+    await this.connect(preferredTarget);
+    return true;
+  }
+
+  async withAutomationMainTab<T>(operation: () => Promise<T>): Promise<T> {
+    const previousTargetId = this.state.activeTabId ?? this.lastTargetId;
+    await this.connectToAutomationMainTab();
+
+    try {
+      return await operation();
+    } finally {
+      if (previousTargetId && previousTargetId !== this.automationMainTabId) {
+        try {
+          const targets = await this.listTargets();
+          if (targets.some(t => t.id === previousTargetId)) {
+            await this.connect(previousTargetId);
+          }
+        } catch {
+          // Keep control tab connection if restoring the previous tab fails
+        }
+      }
+    }
+  }
+
+  async getVisibleTabContexts(): Promise<TabContext[]> {
+    const tabs = await this.getTabContexts();
+    return tabs.filter(t => !this.isInternalTab(t.url));
+  }
+
+  async forceRestartComet(port: number = this.state.port): Promise<string> {
+    this.state.port = port;
+    await this.killComet();
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    await this.launchCometProcess(port);
+    await this.waitForDebugPort(port);
+    return `Comet force-restarted on mode=${getProfileModeLabel()} port ${port}`;
+  }
+
+  getAutomationMainTabId(): string | undefined {
+    return this.automationMainTabId;
+  }
+
+  setAutomationMainTabId(tabId: string | undefined): void {
+    this.automationMainTabId = tabId;
+  }
+
+  /**
+   * Ensure we're connected to the main Perplexity tab
+   * Used during agentic browsing when Comet may open new tabs
+   */
 
   /**
    * Ensure we're connected to the main Perplexity tab
@@ -405,50 +787,16 @@ export class CometCDPClient {
    */
   async ensureOnPerplexityTab(): Promise<boolean> {
     try {
-      // First check if current connection is valid and on Perplexity
-      if (this.client) {
-        try {
-          const urlResult = await this.client.Runtime.evaluate({
-            expression: 'window.location.href',
-            timeout: 2000
-          });
-          const currentUrl = urlResult.result.value as string;
-          if (currentUrl?.includes('perplexity.ai')) {
-            return true; // Already on Perplexity tab
-          }
-        } catch {
-          // Current connection is stale, continue to reconnect
-        }
-      }
-
-      // Find and connect to Perplexity main tab
-      const tabs = await this.listTabsCategorized();
-      if (tabs.main) {
-        await this.connect(tabs.main.id);
-        this.invalidateHealthCache();
-        return true;
-      }
-
-      // Fallback: find any Perplexity tab
-      const targets = await this.listTargets();
-      const perplexityTab = targets.find(t =>
-        t.type === 'page' && t.url.includes('perplexity.ai')
-      );
-
-      if (perplexityTab) {
-        await this.connect(perplexityTab.id);
-        this.invalidateHealthCache();
-        return true;
-      }
-
-      return false;
+      await this.connectToAutomationMainTab();
+      this.invalidateHealthCache();
+      return true;
     } catch {
       return false;
     }
   }
 
   /**
-   * Check if we're currently connected to the Perplexity tab
+   * Check if we're currently connected to the Perplexity control tab
    */
   async isOnPerplexityTab(): Promise<boolean> {
     if (!this.client) return false;
@@ -458,10 +806,51 @@ export class CometCDPClient {
         timeout: 2000
       });
       const url = result.result.value as string;
-      return url?.includes('perplexity.ai') || false;
+      return this.isPerplexityUrl(url) && (!this.automationMainTabId || this.state.activeTabId === this.automationMainTabId);
     } catch {
       return false;
     }
+  }
+
+  async isAutomationMainTab(targetId: string | undefined): Promise<boolean> {
+    return Boolean(targetId && this.automationMainTabId && targetId === this.automationMainTabId);
+  }
+
+  async getActiveTabContext(): Promise<TabContext | null> {
+    const tabs = await this.getTabContexts();
+    const activeTabId = this.state.activeTabId ?? this.lastTargetId;
+    return tabs.find(tab => tab.id === activeTabId) || null;
+  }
+
+  async getBrowsingTabCount(): Promise<number> {
+    const tabs = await this.getVisibleTabContexts();
+    return tabs.length;
+  }
+
+  async getClosableTabCount(): Promise<number> {
+    const tabs = await this.getVisibleTabContexts();
+    return tabs.filter(tab => tab.id !== this.automationMainTabId).length;
+  }
+
+  async isControlTabAvailable(): Promise<boolean> {
+    return Boolean(await this.getAutomationMainTab());
+  }
+
+  async closeTrackedTab(targetId: string): Promise<boolean> {
+    const success = await this.closeTab(targetId);
+    if (success) {
+      this.tabRegistry.delete(targetId);
+      if (this.automationMainTabId === targetId) {
+        this.automationMainTabId = undefined;
+      }
+      if (this.lastTargetId === targetId) {
+        this.lastTargetId = undefined;
+      }
+      if (this.state.activeTabId === targetId) {
+        this.state.activeTabId = undefined;
+      }
+    }
+    return success;
   }
 
   // ============ TAB REGISTRY METHODS ============
@@ -482,30 +871,21 @@ export class CometCDPClient {
    * Check if URL is an internal Chrome/Comet page (not a real browsing tab)
    */
   private isInternalTab(url: string): boolean {
-    // Chrome internal pages
-    if (url.startsWith('chrome://') ||
-        url.startsWith('chrome-extension://') ||
-        url.startsWith('devtools://') ||
-        url === 'about:blank' ||
-        url === '') {
-      return true;
-    }
-
-    // ALL Perplexity URLs are internal Comet UI, not real browsing tabs
-    if (url.includes('perplexity.ai')) {
-      return true;
-    }
-
-    return false;
+    return url.startsWith('chrome://') ||
+      url.startsWith('chrome-extension://') ||
+      url.startsWith('devtools://') ||
+      url === 'about:blank' ||
+      url === '';
   }
 
   /**
    * Infer tab purpose from URL and context
    */
-  private inferPurpose(url: string, title: string): TabContext['purpose'] {
+  private inferPurpose(url: string, title: string, targetId?: string): TabContext['purpose'] {
     if (this.isInternalTab(url)) return 'unknown';
-    if (url.includes('perplexity.ai')) return 'main';
-    // Default to agent-browsing for external sites
+    if ((targetId && targetId === this.automationMainTabId) || this.isPerplexityUrl(url)) return 'main';
+    // Only label tabs opened during this session as agent-browsing
+    if (targetId && this.baselineTabIds.has(targetId)) return 'unknown';
     return 'agent-browsing';
   }
 
@@ -533,13 +913,16 @@ export class CometCDPClient {
 
       if (existing) {
         // Update existing entry
+        const previousDomain = existing.domain;
         existing.url = target.url;
         existing.title = target.title;
         existing.domain = domain;
         existing.lastActivity = currentTime;
-        // Re-infer purpose if URL changed significantly
-        if (existing.domain !== domain) {
-          existing.purpose = this.inferPurpose(target.url, target.title);
+        if (previousDomain !== domain || existing.purpose === 'unknown') {
+          existing.purpose = this.inferPurpose(target.url, target.title, target.id);
+        }
+        if (target.id === this.automationMainTabId) {
+          existing.purpose = 'main';
         }
       } else {
         // New tab - create entry
@@ -547,11 +930,18 @@ export class CometCDPClient {
           id: target.id,
           url: target.url,
           title: target.title,
-          purpose: this.inferPurpose(target.url, target.title),
+          purpose: this.inferPurpose(target.url, target.title, target.id),
           domain,
           lastActivity: currentTime,
         };
         this.tabRegistry.set(target.id, context);
+      }
+
+      if (target.id === this.automationMainTabId) {
+        const controlTab = this.tabRegistry.get(target.id);
+        if (controlTab) {
+          controlTab.purpose = 'main';
+        }
       }
     }
 
@@ -670,10 +1060,7 @@ export class CometCDPClient {
    * Get formatted tab summary for context display (filters out internal Chrome tabs)
    */
   async getTabSummary(): Promise<string> {
-    const allTabs = await this.getTabContexts();
-
-    // Filter out internal Chrome tabs - only show real browsing tabs
-    const tabs = allTabs.filter(t => !this.isInternalTab(t.url));
+    const tabs = await this.getVisibleTabContexts();
 
     if (tabs.length === 0) {
       return "No browsing tabs open";
@@ -685,7 +1072,8 @@ export class CometCDPClient {
       const active = tab.id === this.state.activeTabId ? " [ACTIVE]" : "";
       const task = tab.taskId ? ` (task: ${tab.taskId})` : "";
       const summary = tab.contentSummary ? ` - ${tab.contentSummary}` : "";
-      lines.push(`  • ${tab.purpose.toUpperCase()}: ${tab.domain}${active}${task}${summary}`);
+      const label = tab.purpose === 'unknown' ? 'TAB' : tab.purpose.toUpperCase();
+      lines.push(`  • ${label}: ${tab.domain}${active}${task}${summary}`);
       lines.push(`    URL: ${tab.url.substring(0, 80)}${tab.url.length > 80 ? '...' : ''}`);
     }
 
@@ -740,206 +1128,82 @@ export class CometCDPClient {
    */
   async startComet(port: number = DEFAULT_PORT): Promise<string> {
     this.state.port = port;
+    let config = this.getAutomationConfig();
 
-    // On WSL, use HTTP via PowerShell (WebSocket doesn't work across WSL/Windows boundary)
-    if (IS_WSL) {
-      // Check if Comet is already running with debug port via HTTP
-      try {
-        const response = await windowsFetch(`http://127.0.0.1:${port}/json/version`);
-        if (response.ok) {
-          const version = await response.json() as CDPVersion;
-          return `Comet already running on Windows host, port: ${port} (${version.Browser})`;
-        }
-      } catch {
-        // Comet not accessible, need to launch
+    if (await this.isDebugPortReachable(port)) {
+      const isExpectedAutomation = await this.isExpectedAutomationInstance(port);
+      if (isExpectedAutomation) {
+        console.error(`[comet] Using existing automation instance ${formatAutomationDescriptor(port)}`);
+        return `Comet automation already running on port ${port} (mode=${config.profileMode}, profile=${config.profileDir}, userDataDir=${config.userDataDir})`;
       }
 
-      // Try to launch Comet via PowerShell on Windows
-      console.error('Comet not accessible, attempting to launch via PowerShell...');
-
-      // Get Windows user's LOCALAPPDATA path
-      let cometPath = '';
-      try {
-        const localAppData = execSync('cmd.exe /c echo %LOCALAPPDATA%', { encoding: 'utf8' }).trim().replace(/\r?\n/g, '');
-        cometPath = `${localAppData}\\Perplexity\\Comet\\Application\\Comet.exe`;
-      } catch {
-        cometPath = 'C:\\Users\\' + (process.env.USER || 'user') + '\\AppData\\Local\\Perplexity\\Comet\\Application\\Comet.exe';
+      const existingAutomationPort = await this.findRunningAutomationPort(port + 1);
+      if (existingAutomationPort !== null) {
+        this.state.port = existingAutomationPort;
+        config = this.getAutomationConfig();
+        console.error(`[comet] Debug port ${port} is attached to a non-automation Comet instance; reusing automation ${formatAutomationDescriptor(existingAutomationPort)}.`);
+        return `Comet automation already running on fallback port ${existingAutomationPort} (mode=${config.profileMode}, profile=${config.profileDir}, userDataDir=${config.userDataDir})`;
       }
 
-      try {
-        // Launch Comet via PowerShell
-        // Use Set-Location to avoid UNC path issues when running from WSL
-        const psCommand = `Set-Location C:\\; Start-Process -FilePath '${cometPath}' -ArgumentList '--remote-debugging-port=${port}'`;
-        spawn('powershell.exe', ['-NoProfile', '-Command', psCommand], {
-          detached: true,
-          stdio: 'ignore',
-        }).unref();
-
-        // Wait for Comet to start - use HTTP check via PowerShell
-        return new Promise((resolve, reject) => {
-          const maxAttempts = 40;
-          let attempts = 0;
-
-          const checkReady = async () => {
-            attempts++;
-            try {
-              const response = await windowsFetch(`http://127.0.0.1:${port}/json/version`);
-              if (response.ok) {
-                resolve(`Comet started via WSL->PowerShell on port ${port}`);
-                return;
-              }
-            } catch { /* keep trying */ }
-
-            if (attempts < maxAttempts) {
-              setTimeout(checkReady, 500);
-            } else {
-              reject(new Error(
-                `Timeout waiting for Comet. Tried to launch: ${cometPath}\n` +
-                `Try manually: powershell.exe -Command "Start-Process '${cometPath}' -ArgumentList '--remote-debugging-port=${port}'"`
-              ));
-            }
-          };
-
-          setTimeout(checkReady, 2000);
-        });
-      } catch (launchError) {
-        throw new Error(
-          `Cannot connect to or launch Comet browser.\n` +
-          `Tried path: ${cometPath}\n` +
-          `Error: ${launchError instanceof Error ? launchError.message : String(launchError)}`
-        );
-      }
+      const fallbackPort = await this.findAvailableDebugPort(port + 1);
+      this.state.port = fallbackPort;
+      config = this.getAutomationConfig();
+      console.error(`[comet] Debug port ${port} is attached to a non-automation Comet instance; launching automation ${formatAutomationDescriptor(fallbackPort)}.`);
+      await this.launchCometProcess(fallbackPort);
+      await this.waitForDebugPort(fallbackPort, IS_WSL ? 2000 : 1500);
+      return `Comet automation started on fallback port ${fallbackPort} (mode=${config.profileMode}, profile=${config.profileDir}, userDataDir=${config.userDataDir})`;
     }
 
-    // On Windows (native), try direct WebSocket connection first (bypasses HTTP issues)
-    if (IS_WINDOWS) {
-      try {
-        // Try to connect directly via CDP WebSocket
-        const testClient = await CDP({ port, host: '127.0.0.1' });
-        await testClient.close();
-        return `Comet already running with debug port: ${port}`;
-      } catch {
-        // Comet not running or not accessible, check if process exists
-        const isRunning = await this.isCometProcessRunning();
-        if (!isRunning) {
-          // Start Comet
-          this.cometProcess = spawn(COMET_PATH, [`--remote-debugging-port=${port}`], {
-            detached: true,
-            stdio: "ignore",
-          });
-          this.cometProcess.unref();
-
-          // Wait for Comet to start and try WebSocket connection
-          return new Promise((resolve, reject) => {
-            const maxAttempts = 40;
-            let attempts = 0;
-
-            const checkReady = async () => {
-              attempts++;
-              try {
-                const testClient = await CDP({ port, host: '127.0.0.1' });
-                await testClient.close();
-                resolve(`Comet started with debug port ${port}`);
-                return;
-              } catch { /* keep trying */ }
-
-              if (attempts < maxAttempts) {
-                setTimeout(checkReady, 500);
-              } else {
-                reject(new Error(`Timeout waiting for Comet. Try running: "${COMET_PATH}" --remote-debugging-port=${port}`));
-              }
-            };
-
-            setTimeout(checkReady, 1500);
-          });
-        } else {
-          // Process running but CDP not accessible - need restart with debug port
-          await this.killComet();
-          await new Promise(r => setTimeout(r, 1000));
-
-          this.cometProcess = spawn(COMET_PATH, [`--remote-debugging-port=${port}`], {
-            detached: true,
-            stdio: "ignore",
-          });
-          this.cometProcess.unref();
-
-          return new Promise((resolve, reject) => {
-            const maxAttempts = 40;
-            let attempts = 0;
-
-            const checkReady = async () => {
-              attempts++;
-              try {
-                const testClient = await CDP({ port, host: '127.0.0.1' });
-                await testClient.close();
-                resolve(`Comet restarted with debug port ${port}`);
-                return;
-              } catch { /* keep trying */ }
-
-              if (attempts < maxAttempts) {
-                setTimeout(checkReady, 500);
-              } else {
-                reject(new Error(`Timeout waiting for Comet. Try running: "${COMET_PATH}" --remote-debugging-port=${port}`));
-              }
-            };
-
-            setTimeout(checkReady, 1500);
-          });
-        }
+    const isRunning = await this.isCometProcessRunning();
+    if (isRunning) {
+      // Search for our automation on nearby ports first
+      const existingAutomationPort = await this.findRunningAutomationPort(port);
+      if (existingAutomationPort !== null) {
+        this.state.port = existingAutomationPort;
+        config = this.getAutomationConfig();
+        console.error(`[comet] Found existing automation ${formatAutomationDescriptor(existingAutomationPort)}.`);
+        return `Comet automation already running on port ${existingAutomationPort} (mode=${config.profileMode}, profile=${config.profileDir}, userDataDir=${config.userDataDir})`;
       }
-    }
 
-    // Non-Windows: use original HTTP-based approach
-    try {
-      const response = await windowsFetch(`http://127.0.0.1:${port}/json/version`);
-
-      if (response.ok) {
-        const version = await response.json() as CDPVersion;
-        return `Comet already running with debug port: ${version.Browser}`;
-      }
-    } catch {
-      const isRunning = await this.isCometProcessRunning();
-      if (isRunning) {
-        await this.killComet();
-      }
-    }
-
-    // Start Comet
-    return new Promise((resolve, reject) => {
-      this.cometProcess = spawn(COMET_PATH, [`--remote-debugging-port=${port}`], {
-        detached: true,
-        stdio: "ignore",
-      });
-      this.cometProcess.unref();
-
-      const maxAttempts = 40;
-      let attempts = 0;
-
-      const checkReady = async () => {
-        attempts++;
-        try {
-          const response = await windowsFetch(`http://127.0.0.1:${port}/json/version`);
-
-          if (response.ok) {
-            const version = await response.json() as CDPVersion;
-            resolve(`Comet started with debug port ${port}: ${version.Browser}`);
-            return;
+      if (getProfileMode() === 'default') {
+        // Default-profile mode: Comet is running but without CDP.
+        // Try common debug ports first (in case it was launched with one we didn't check).
+        for (const probePort of [9222, 9223, 9224, 9225]) {
+          if (probePort === port) continue; // Already checked above
+          if (await this.isDebugPortReachable(probePort)) {
+            this.state.port = probePort;
+            config = this.getAutomationConfig();
+            console.error(`[comet] Default-profile mode: found existing CDP on port ${probePort}. No restart needed.`);
+            return `Comet automation found on port ${probePort} (mode=${config.profileMode}, profile=${config.profileDir}, userDataDir=${config.userDataDir})`;
           }
-        } catch { /* keep trying */ }
-
-        if (attempts < maxAttempts) {
-          setTimeout(checkReady, 500);
-        } else {
-          const hint = IS_WINDOWS
-            ? `Try running: "${COMET_PATH}" --remote-debugging-port=${port}`
-            : `Try: ${COMET_PATH} --remote-debugging-port=${port}`;
-          reject(new Error(`Timeout waiting for Comet. ${hint}`));
         }
-      };
 
-      setTimeout(checkReady, 1500);
-    });
+        // No CDP port found — must restart with CDP enabled.
+        // --restore-last-session preserves their open tabs; --new-window avoids losing focus.
+        console.error(`[comet] Default-profile mode: Comet running without CDP. Restarting with CDP on port ${port}. Open tabs will be restored via --restore-last-session.`);
+        await this.killComet();
+        await new Promise(resolve => setTimeout(resolve, 2000));
+        await this.launchCometProcess(port, true);
+        await this.waitForDebugPort(port, IS_WSL ? 3000 : 2500);
+
+        config = this.getAutomationConfig();
+        return `Comet automation started on port ${port} (mode=${config.profileMode}, profile=${config.profileDir}, userDataDir=${config.userDataDir})`;
+      }
+
+      console.error(`[comet] Existing Comet process detected without CDP on port ${port}; leaving it untouched and launching automation ${formatAutomationDescriptor(port)}.`);
+    } else {
+      console.error(`[comet] Launching automation ${formatAutomationDescriptor(port)}.`);
+    }
+
+    await this.launchCometProcess(port);
+    await this.waitForDebugPort(port, IS_WSL ? 2000 : 1500);
+
+    return `Comet automation started on port ${port} (mode=${config.profileMode}, profile=${config.profileDir}, userDataDir=${config.userDataDir})`;
   }
+
+  /**
+   * Get CDP version info
+   */
 
   /**
    * Get CDP version info
@@ -1146,8 +1410,37 @@ export class CometCDPClient {
    */
   async pressKey(key: string): Promise<void> {
     this.ensureConnected();
+
+    if (key === "Enter") {
+      await this.client!.Input.dispatchKeyEvent({
+        type: "keyDown",
+        key: "Enter",
+        code: "Enter",
+        windowsVirtualKeyCode: 13,
+        nativeVirtualKeyCode: 13,
+        unmodifiedText: "\r",
+        text: "\r",
+      });
+      await this.client!.Input.dispatchKeyEvent({
+        type: "keyUp",
+        key: "Enter",
+        code: "Enter",
+        windowsVirtualKeyCode: 13,
+        nativeVirtualKeyCode: 13,
+      });
+      return;
+    }
+
     await this.client!.Input.dispatchKeyEvent({ type: "keyDown", key });
     await this.client!.Input.dispatchKeyEvent({ type: "keyUp", key });
+  }
+
+  /**
+   * Insert text via CDP (fires native input events, compatible with React)
+   */
+  async insertText(text: string): Promise<void> {
+    this.ensureConnected();
+    await this.client!.Input.insertText({ text });
   }
 
   /**

--- a/src/cdp-client.ts
+++ b/src/cdp-client.ts
@@ -585,7 +585,8 @@ export class CometCDPClient {
       });
     }
 
-    return false;
+    // Non-Windows: accept any reachable debug port as the expected instance
+    return true;
   }
 
   private async getBrowserCommandLine(port: number): Promise<string[] | null> {
@@ -775,11 +776,6 @@ export class CometCDPClient {
   setAutomationMainTabId(tabId: string | undefined): void {
     this.automationMainTabId = tabId;
   }
-
-  /**
-   * Ensure we're connected to the main Perplexity tab
-   * Used during agentic browsing when Comet may open new tabs
-   */
 
   /**
    * Ensure we're connected to the main Perplexity tab

--- a/src/cdp-client.ts
+++ b/src/cdp-client.ts
@@ -1178,16 +1178,28 @@ export class CometCDPClient {
           }
         }
 
-        // No CDP port found — must restart with CDP enabled.
-        // --restore-last-session preserves their open tabs; --new-window avoids losing focus.
-        console.error(`[comet] Default-profile mode: Comet running without CDP. Restarting with CDP on port ${port}. Open tabs will be restored via --restore-last-session.`);
-        await this.killComet();
-        await new Promise(resolve => setTimeout(resolve, 2000));
-        await this.launchCometProcess(port, true);
-        await this.waitForDebugPort(port, IS_WSL ? 3000 : 2500);
+        // No CDP port found. Respect existing Comet windows by default.
+        const forceRestart = process.env.COMET_FORCE_RESTART === 'true';
+        if (forceRestart) {
+          // Opt-in restart: kill and relaunch with CDP + --restore-last-session to preserve tabs.
+          console.error(`[comet] Default-profile mode: COMET_FORCE_RESTART=true. Restarting Comet with CDP on port ${port}. Open tabs will be restored via --restore-last-session.`);
+          await this.killComet();
+          await new Promise(resolve => setTimeout(resolve, 2000));
+          await this.launchCometProcess(port, true);
+          await this.waitForDebugPort(port, IS_WSL ? 3000 : 2500);
+          config = this.getAutomationConfig();
+          return `Comet automation started on port ${port} (mode=${config.profileMode}, profile=${config.profileDir}, userDataDir=${config.userDataDir})`;
+        }
 
-        config = this.getAutomationConfig();
-        return `Comet automation started on port ${port} (mode=${config.profileMode}, profile=${config.profileDir}, userDataDir=${config.userDataDir})`;
+        // Non-destructive: tell the user how to start Comet with CDP themselves.
+        const cometPath = COMET_PATH;
+        console.error(`[comet] Default-profile mode: Comet is running without CDP. Cannot attach without restarting.`);
+        console.error(`[comet] To enable CDP, close Comet and relaunch with: "${cometPath}" --remote-debugging-port=${port} --restore-last-session --new-window`);
+        console.error(`[comet] Or set COMET_FORCE_RESTART=true to allow automatic restart.`);
+        return `Comet is running without CDP (remote debugging). To connect:\n` +
+          `1. Close Comet and relaunch with: "${cometPath}" --remote-debugging-port=${port} --restore-last-session --new-window\n` +
+          `2. Or set env var COMET_FORCE_RESTART=true to allow automatic restart (tabs are preserved via --restore-last-session).\n` +
+          `Mode: ${config.profileMode}, Port: ${port}`;
       }
 
       console.error(`[comet] Existing Comet process detected without CDP on port ${port}; leaving it untouched and launching automation ${formatAutomationDescriptor(port)}.`);

--- a/src/comet-ai.ts
+++ b/src/comet-ai.ts
@@ -28,126 +28,82 @@ export class CometAI {
     return null;
   }
 
-  /**
-   * Send a prompt to Comet's AI (Perplexity)
-   */
-  async sendPrompt(prompt: string): Promise<string> {
-    const inputSelector = await this.findInputElement();
-
-    if (!inputSelector) {
-      throw new Error("Could not find input element. Navigate to Perplexity first.");
-    }
-
-    // Use execCommand for contenteditable elements (works with React/Vue)
+  private async getInputContentState(inputSelector: string): Promise<{ hasContent: boolean; value: string; elementType: string }> {
     const result = await cometClient.evaluate(`
       (() => {
-        const el = document.querySelector('[contenteditable="true"]');
-        if (el) {
-          el.focus();
-          document.execCommand('selectAll', false, null);
-          document.execCommand('insertText', false, ${JSON.stringify(prompt)});
-          return { success: true };
+        const el = document.querySelector(${JSON.stringify(inputSelector)});
+        if (!el) return { hasContent: false, value: '', elementType: 'missing' };
+
+        if (el.matches('[contenteditable="true"]')) {
+          const value = el.innerText.trim();
+          return { hasContent: value.length > 0, value, elementType: 'contenteditable' };
         }
-        // Fallback for textarea
-        const textarea = document.querySelector('textarea');
-        if (textarea) {
-          textarea.focus();
-          textarea.value = ${JSON.stringify(prompt)};
-          textarea.dispatchEvent(new Event('input', { bubbles: true }));
-          return { success: true };
+
+        if (el instanceof HTMLTextAreaElement) {
+          const value = el.value.trim();
+          return { hasContent: value.length > 0, value, elementType: 'textarea' };
         }
-        return { success: false };
+
+        if (el instanceof HTMLInputElement && el.type === 'text') {
+          const value = el.value.trim();
+          return { hasContent: value.length > 0, value, elementType: 'text-input' };
+        }
+
+        return { hasContent: false, value: '', elementType: 'unsupported' };
       })()
     `);
 
-    const typed = (result.result.value as { success: boolean })?.success;
-    if (!typed) {
-      throw new Error("Failed to type into input element");
-    }
-
-    // Submit the prompt
-    await this.submitPrompt();
-
-    return `Prompt sent: "${prompt.substring(0, 50)}${prompt.length > 50 ? '...' : ''}"`;
+    return (result.result.value as { hasContent: boolean; value: string; elementType: string }) || { hasContent: false, value: '', elementType: 'missing' };
   }
 
-  /**
-   * Submit the current prompt
-   */
-  private async submitPrompt(): Promise<void> {
-    // Wait for React to process the typed content
-    await new Promise(resolve => setTimeout(resolve, 300));
+  private async verifyInputHasContent(inputSelector: string): Promise<boolean> {
+    const state = await this.getInputContentState(inputSelector);
+    return state.hasContent;
+  }
 
-    // Verify text was typed before attempting submit
-    const hasContent = await cometClient.evaluate(`
+  private async isPromptSubmitted(inputSelector: string): Promise<boolean> {
+    const result = await cometClient.evaluate(`
       (() => {
-        const el = document.querySelector('[contenteditable="true"]');
-        if (el && el.innerText.trim().length > 0) return true;
-        const textarea = document.querySelector('textarea');
-        if (textarea && textarea.value.trim().length > 0) return true;
-        return false;
-      })()
-    `);
-
-    if (!hasContent.result.value) {
-      throw new Error("Prompt text not found in input - typing may have failed");
-    }
-
-    // Strategy 1: Simulate Enter key via DOM events (most reliable for contenteditable)
-    const enterResult = await cometClient.evaluate(`
-      (() => {
-        const el = document.querySelector('[contenteditable="true"]') ||
-                   document.querySelector('textarea');
-        if (!el) return { success: false, reason: 'no input element' };
-
-        el.focus();
-
-        // Create and dispatch Enter key events
-        const enterEvent = new KeyboardEvent('keydown', {
-          key: 'Enter',
-          code: 'Enter',
-          keyCode: 13,
-          which: 13,
-          bubbles: true,
-          cancelable: true
-        });
-
-        el.dispatchEvent(enterEvent);
-
-        // Also dispatch keyup
-        const keyupEvent = new KeyboardEvent('keyup', {
-          key: 'Enter',
-          code: 'Enter',
-          keyCode: 13,
-          which: 13,
-          bubbles: true
-        });
-        el.dispatchEvent(keyupEvent);
-
-        return { success: true };
-      })()
-    `);
-
-    await new Promise(resolve => setTimeout(resolve, 800));
-
-    // Check if submission worked
-    const submitted = await cometClient.evaluate(`
-      (() => {
-        const el = document.querySelector('[contenteditable="true"]');
-        // If input is empty or nearly empty, submission worked
-        if (el && el.innerText.trim().length < 5) return true;
-        // Check for loading indicators
+        const el = document.querySelector(${JSON.stringify(inputSelector)});
         const hasLoading = document.querySelector('[class*="animate-spin"], [class*="animate-pulse"]') !== null;
-        const hasThinking = document.body.innerText.includes('Thinking');
-        return hasLoading || hasThinking;
+
+        // Check for "Thinking" as a status indicator, excluding model names
+        let hasThinking = false;
+        const body = document.body.innerText;
+        const thinkIdx = body.indexOf('Thinking');
+        if (thinkIdx !== -1) {
+          const before = body.substring(Math.max(0, thinkIdx - 30), thinkIdx);
+          const isModelName = before.includes('Sonnet') || before.includes('Opus') ||
+            before.includes('Claude') || before.includes('Haiku') ||
+            before.includes('4.6') || before.includes('4.5') || before.includes('3.5');
+          hasThinking = !isModelName;
+        }
+
+        // URL change is a strong signal (home -> search results)
+        const urlChanged = window.location.pathname.startsWith('/search/');
+
+        if (!el) return hasLoading || hasThinking || urlChanged;
+
+        let remainingLength = 999;
+        if (el.matches('[contenteditable="true"]')) {
+          remainingLength = el.innerText.trim().length;
+        } else if (el instanceof HTMLTextAreaElement || (el instanceof HTMLInputElement && el.type === 'text')) {
+          remainingLength = el.value.trim().length;
+        }
+
+        return remainingLength < 5 || hasLoading || hasThinking || urlChanged;
       })()
     `);
-    if (submitted.result.value) return;
 
-    // Strategy 2: Click the submit button directly
-    const clickResult = await cometClient.evaluate(`
+    return Boolean(result.result.value);
+  }
+
+  private async detectSubmitButton(inputSelector: string): Promise<{ selector: string | null; method: string | null }> {
+    const result = await cometClient.evaluate(`
       (() => {
-        // Try specific submit button selectors first
+        const inputEl = document.querySelector(${JSON.stringify(inputSelector)});
+        if (!inputEl) return { selector: null, method: null };
+
         const selectors = [
           'button[aria-label*="Submit"]',
           'button[aria-label*="Send"]',
@@ -159,79 +115,256 @@ export class CometAI {
         for (const sel of selectors) {
           const btn = document.querySelector(sel);
           if (btn && !btn.disabled && btn.offsetParent !== null) {
-            btn.click();
-            return { success: true, method: 'selector', selector: sel };
+            return { selector: sel, method: 'selector' };
           }
         }
 
-        // Find the submit button by position (usually rightmost button near input)
-        const inputEl = document.querySelector('[contenteditable="true"]') ||
-                        document.querySelector('textarea');
-        if (inputEl) {
-          const inputRect = inputEl.getBoundingClientRect();
-          let parent = inputEl.parentElement;
-          let candidates = [];
+        let parent = inputEl.parentElement;
+        const candidates = [];
 
-          // Search up the DOM tree
-          for (let i = 0; i < 5 && parent; i++) {
-            const btns = parent.querySelectorAll('button');
-            for (const btn of btns) {
-              if (btn.disabled || btn.offsetParent === null) continue;
+        for (let depth = 0; depth < 5 && parent; depth++) {
+          const buttons = parent.querySelectorAll('button');
+          buttons.forEach((btn, index) => {
+            if (btn.disabled || btn.offsetParent === null) return;
 
-              const btnRect = btn.getBoundingClientRect();
-              const ariaLabel = (btn.getAttribute('aria-label') || '').toLowerCase();
-
-              // Skip mode/attach/voice/menu buttons
-              if (ariaLabel.includes('search') || ariaLabel.includes('research') ||
-                  ariaLabel.includes('labs') || ariaLabel.includes('learn') ||
-                  ariaLabel.includes('attach') || ariaLabel.includes('voice') ||
-                  ariaLabel.includes('menu') || ariaLabel.includes('more')) {
-                continue;
-              }
-
-              // Button should be visible and to the right of input
-              if (btnRect.width > 0 && btnRect.height > 0) {
-                candidates.push({ btn, x: btnRect.right, y: btnRect.top });
-              }
+            const ariaLabel = (btn.getAttribute('aria-label') || '').toLowerCase();
+            if (ariaLabel.includes('search') || ariaLabel.includes('research') ||
+                ariaLabel.includes('labs') || ariaLabel.includes('learn') ||
+                ariaLabel.includes('attach') || ariaLabel.includes('voice') ||
+                ariaLabel.includes('menu') || ariaLabel.includes('more')) {
+              return;
             }
-            parent = parent.parentElement;
-          }
 
-          // Click the rightmost button (usually submit)
-          if (candidates.length > 0) {
-            candidates.sort((a, b) => b.x - a.x);
-            candidates[0].btn.click();
-            return { success: true, method: 'position' };
-          }
+            let selector = btn.id ? ('#' + btn.id) : '';
+            if (!selector) {
+              const buttonType = btn.getAttribute('type');
+              selector = buttonType ? ('button[type="' + buttonType + '"]') : 'button';
+              const sameTypeButtons = Array.from(parent.querySelectorAll(selector));
+              const position = sameTypeButtons.indexOf(btn) + 1;
+              selector = selector + ':nth-of-type(' + (position || index + 1) + ')';
+            }
+
+            const rect = btn.getBoundingClientRect();
+            candidates.push({ selector, x: rect.right });
+          });
+          parent = parent.parentElement;
         }
 
-        return { success: false, reason: 'no button found' };
+        candidates.sort((a, b) => b.x - a.x);
+        return { selector: candidates[0]?.selector || null, method: candidates[0] ? 'position' : null };
       })()
     `);
 
+    return (result.result.value as { selector: string | null; method: string | null }) || { selector: null, method: null };
+  }
+
+  /**
+   * Send a prompt to Comet's AI (Perplexity)
+   */
+  async sendPrompt(prompt: string): Promise<string> {
+    const inputSelector = await this.findInputElement();
+
+    if (!inputSelector) {
+      throw new Error("Could not find input element. Navigate to Perplexity first.");
+    }
+
+    console.error(`[comet] Input selector chosen: ${inputSelector}`);
+
+    const typingResult = await cometClient.evaluate(`
+      (() => {
+        const el = document.querySelector(${JSON.stringify(inputSelector)});
+        if (!el) {
+          return { success: false, path: null, reason: 'input-not-found' };
+        }
+
+        const promptText = ${JSON.stringify(prompt)};
+
+        if (el.matches('[contenteditable="true"]')) {
+          // Clear existing content with native select-all + delete
+          el.focus();
+          document.execCommand('selectAll', false);
+          document.execCommand('delete', false);
+          el.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'deleteContentBackward' }));
+          // Signal that we need CDP insertText for proper React compatibility
+          return { success: true, path: 'contenteditable-cdp', needsCdpInsert: true };
+        }
+
+        if (el instanceof HTMLTextAreaElement) {
+          el.focus();
+          el.value = promptText;
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+          return { success: true, path: 'textarea' };
+        }
+
+        if (el instanceof HTMLInputElement && el.type === 'text') {
+          el.focus();
+          el.value = promptText;
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+          return { success: true, path: 'text-input' };
+        }
+
+        return { success: false, path: null, reason: 'unsupported-element' };
+      })()
+    `);
+
+    const typed = (typingResult.result.value as { success: boolean; path?: string; reason?: string; needsCdpInsert?: boolean }) || { success: false };
+    if (!typed.success) {
+      throw new Error(`Failed to type into input element (${typed.reason || 'unknown error'})`);
+    }
+
+    // For contenteditable: use CDP insertText for proper React state sync
+    if (typed.needsCdpInsert) {
+      await new Promise(resolve => setTimeout(resolve, 200));
+      await cometClient.insertText(prompt);
+      await new Promise(resolve => setTimeout(resolve, 500));
+    } else {
+      await new Promise(resolve => setTimeout(resolve, 400));
+    }
+
+    const inputState = await this.getInputContentState(inputSelector);
+    const hasTypedContent = inputState.hasContent;
+    console.error(`[comet] Typing path=${typed.path} success=${hasTypedContent} elementType=${inputState.elementType}`);
+
+    if (!hasTypedContent) {
+      throw new Error("Prompt text not found in selected input - typing may have failed");
+    }
+
+    await this.submitPrompt(inputSelector);
+
+    return `Prompt sent: "${prompt.substring(0, 50)}${prompt.length > 50 ? '...' : ''}"`;
+  }
+
+  /**
+   * Submit the current prompt
+   */
+  private async submitPrompt(inputSelector: string): Promise<void> {
     await new Promise(resolve => setTimeout(resolve, 500));
 
-    // Final verification and last resort
-    const finalCheck = await cometClient.evaluate(`
+    const hasContent = await this.verifyInputHasContent(inputSelector);
+    if (!hasContent) {
+      throw new Error("Prompt text not found in selected input - typing may have failed");
+    }
+
+    const contentEditableSubmit = await cometClient.evaluate(`
       (() => {
-        const el = document.querySelector('[contenteditable="true"]');
-        if (el && el.innerText.trim().length < 5) return true;
-        const hasLoading = document.querySelector('[class*="animate"]') !== null;
-        const hasThinking = document.body.innerText.includes('Thinking');
-        return hasLoading || hasThinking;
+        const el = document.querySelector(${JSON.stringify(inputSelector)});
+        if (!el) return false;
+        el.focus();
+        return el.matches('[contenteditable="true"]');
       })()
     `);
 
-    if (!finalCheck.result.value) {
-      // Last resort: try form submit
+    let submitMethod = '';
+
+    if (contentEditableSubmit.result.value === true) {
+      // Dismiss any autocomplete/suggestion overlays that consume Enter
+      await cometClient.pressKey('Escape');
+      await new Promise(resolve => setTimeout(resolve, 300));
+      // Re-focus the input after Escape
       await cometClient.evaluate(`
         (() => {
-          const form = document.querySelector('form');
-          if (form) {
-            form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
-          }
+          const el = document.querySelector(${JSON.stringify(inputSelector)});
+          if (el) el.focus();
         })()
       `);
+      await new Promise(resolve => setTimeout(resolve, 200));
+
+      await cometClient.pressKey('Enter');
+      await new Promise(resolve => setTimeout(resolve, 900));
+      const inputStateAfterEnter = await this.getInputContentState(inputSelector);
+      if (inputStateAfterEnter.value.length === 0 || await this.isPromptSubmitted(inputSelector)) {
+        submitMethod = 'cdp-enter-key';
+      }
+    } else {
+      await cometClient.evaluate(`
+        (() => {
+          const el = document.querySelector(${JSON.stringify(inputSelector)});
+          if (!el) return false;
+
+          el.focus();
+
+          const form = el.closest('form');
+          if (form && typeof form.requestSubmit === 'function') {
+            form.requestSubmit();
+            return true;
+          }
+
+          return false;
+        })()
+      `);
+
+      await new Promise(resolve => setTimeout(resolve, 700));
+      const inputStateAfterPrimaryAttempt = await this.getInputContentState(inputSelector);
+      if (inputStateAfterPrimaryAttempt.value.length === 0 || await this.isPromptSubmitted(inputSelector)) {
+        submitMethod = 'selected-input-submit';
+      }
+    }
+
+    if (!submitMethod) {
+      await cometClient.evaluate(`
+        (() => {
+          const el = document.querySelector(${JSON.stringify(inputSelector)});
+          if (el) el.focus();
+          return true;
+        })()
+      `);
+      await cometClient.pressKey('Enter');
+      await new Promise(resolve => setTimeout(resolve, 900));
+      if (await this.isPromptSubmitted(inputSelector)) {
+        submitMethod = 'cdp-enter-key';
+      }
+    }
+
+    if (!submitMethod) {
+      const submitButton = await this.detectSubmitButton(inputSelector);
+      if (submitButton.selector) {
+        await cometClient.evaluate(`
+          (() => {
+            const btn = document.querySelector(${JSON.stringify(submitButton.selector)});
+            if (btn && !btn.disabled) {
+              btn.click();
+              return true;
+            }
+            return false;
+          })()
+        `);
+        await new Promise(resolve => setTimeout(resolve, 800));
+        if (await this.isPromptSubmitted(inputSelector)) {
+          submitMethod = `click-${submitButton.method || 'button'}`;
+        }
+      }
+    }
+
+    if (!submitMethod) {
+      await cometClient.evaluate(`
+        (() => {
+          const el = document.querySelector(${JSON.stringify(inputSelector)});
+          const form = el?.closest('form') || document.querySelector('form');
+          if (!form) {
+            return false;
+          }
+
+          if (typeof form.requestSubmit === 'function') {
+            form.requestSubmit();
+            return true;
+          }
+
+          form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+          return true;
+        })()
+      `);
+      await new Promise(resolve => setTimeout(resolve, 800));
+      if (await this.isPromptSubmitted(inputSelector)) {
+        submitMethod = 'form-submit-fallback';
+      }
+    }
+
+    console.error(`[comet] Submit strategy=${submitMethod || 'failed'}`);
+
+    if (!submitMethod) {
+      throw new Error("Prompt submission failed after all fallback strategies");
     }
   }
 
@@ -291,21 +424,31 @@ export class CometAI {
       (() => {
         const body = document.body.innerText;
 
-        // Check for active stop button (more comprehensive check)
+        // Check for active stop button — must be specific to avoid false positives
+        // from other buttons with rect SVG elements (share, copy, etc.)
         let hasActiveStopButton = false;
         for (const btn of document.querySelectorAll('button')) {
-          const rect = btn.querySelector('rect');
-          const svg = btn.querySelector('svg');
           const ariaLabel = (btn.getAttribute('aria-label') || '').toLowerCase();
-          const btnText = btn.innerText.toLowerCase();
+          const btnText = btn.innerText.toLowerCase().trim();
 
-          // Stop button indicators: square icon (rect), "stop" label, or specific SVG patterns
-          const isStopButton = rect ||
-                              ariaLabel.includes('stop') ||
-                              ariaLabel.includes('cancel') ||
-                              btnText === 'stop';
+          // Only match explicit stop/cancel buttons by label
+          const isStopByLabel = ariaLabel.includes('stop') ||
+                                ariaLabel.includes('cancel') ||
+                                btnText === 'stop';
 
-          if (isStopButton && btn.offsetParent !== null && !btn.disabled) {
+          // Also check for the specific Perplexity stop pattern:
+          // a small circular button with a square <rect> icon, near the input area
+          let isStopByIcon = false;
+          if (!isStopByLabel) {
+            const rect = btn.querySelector('svg rect');
+            if (rect && btn.offsetParent !== null) {
+              const btnRect = btn.getBoundingClientRect();
+              // Stop button is typically small (< 50px) and near the bottom of the page
+              isStopByIcon = btnRect.width < 50 && btnRect.height < 50 && btnRect.y > window.innerHeight * 0.5;
+            }
+          }
+
+          if ((isStopByLabel || isStopByIcon) && btn.offsetParent !== null && !btn.disabled) {
             hasActiveStopButton = true;
             break;
           }
@@ -316,21 +459,30 @@ export class CometAI {
           '[class*="animate-spin"], [class*="animate-pulse"], [class*="loading"], [class*="thinking"]'
         ) !== null;
 
-        // Check for "Thinking" indicator specifically
-        const hasThinkingIndicator = body.includes('Thinking') && !body.includes('Thinking about');
+        // Check for "Thinking" indicator — exclude model names like "Claude Sonnet 4.6 Thinking"
+        // Look for standalone "Thinking" (as a status indicator), not as part of a model name
+        const thinkingIdx = body.indexOf('Thinking');
+        let hasThinkingIndicator = false;
+        if (thinkingIdx !== -1 && !body.includes('Thinking about')) {
+          const before = body.substring(Math.max(0, thinkingIdx - 30), thinkingIdx);
+          const isModelName = before.includes('Sonnet') || before.includes('Opus') ||
+            before.includes('Claude') || before.includes('Haiku') ||
+            before.includes('4.6') || before.includes('4.5') || before.includes('3.5');
+          hasThinkingIndicator = !isModelName;
+        }
 
         const hasStepsCompleted = /\\d+ steps? completed/i.test(body);
         const hasFinishedMarker = body.includes('Finished') && !hasActiveStopButton;
         const hasReviewedSources = /Reviewed \\d+ sources?/i.test(body);
         const hasSourcesIndicator = /\\d+\\s*sources?/i.test(body); // "10 sources" etc
-        const hasAskFollowUp = body.includes('Ask a follow-up') || body.includes('Ask follow-up');
+        const hasAskFollowUp = body.includes('Ask a follow-up') || body.includes('Ask follow-up') || body.includes('Ask anything');
 
         // Check for prose content (actual response) - lowered threshold for short answers
         const proseEls = [...document.querySelectorAll('[class*="prose"]')];
         const hasProseContent = proseEls.some(el => {
           const text = el.innerText.trim();
-          // Must have some content, not just UI text (lowered from 50 to 15 for short answers)
-          return text.length > 15 && !text.startsWith('Library') && !text.startsWith('Discover');
+          // Allow short but real answers while excluding obvious UI labels
+          return text.length > 8 && !text.startsWith('Library') && !text.startsWith('Discover');
         });
 
         // Check if input is focused (user might be typing, not agent working)
@@ -412,7 +564,7 @@ export class CometAI {
           }
 
           // Strategy 2: If no steps marker, look for content after source citations
-          if (!response || response.length < 50) {
+          if (!response || response.length < 12) {
             const sourcesMatch = bodyText.match(/Reviewed\\s+\\d+\\s+sources?/i);
             if (sourcesMatch) {
               const markerIndex = bodyText.indexOf(sourcesMatch[0]);
@@ -430,7 +582,7 @@ export class CometAI {
           }
 
           // Strategy 3: Fallback - get all prose content combined
-          if (!response || response.length < 50) {
+          if (!response || response.length < 12) {
             const allProseEls = [...mainContent.querySelectorAll('[class*="prose"]')];
             const validTexts = allProseEls
               .filter(el => {
@@ -438,7 +590,7 @@ export class CometAI {
                 const text = el.innerText.trim();
                 const isUIText = ['Library', 'Discover', 'Spaces', 'Finance', 'Account',
                                   'Upgrade', 'Home', 'Search'].some(ui => text.startsWith(ui));
-                return !isUIText && text.length > 30;
+                return !isUIText && text.length > 8;
               })
               .map(el => el.innerText.trim());
 
@@ -475,19 +627,19 @@ export class CometAI {
       })()
     `);
 
-    const statusResult = result.result.value as {
+    const statusResult = (result.result.value as {
       status: "idle" | "working" | "completed";
       steps: string[];
       currentStep: string;
       response: string;
       hasStopButton: boolean;
-    };
+    }) || { status: 'idle' as const, steps: [], currentStep: '', response: '', hasStopButton: false };
 
     // Check response stability
     const isStable = this.isResponseStable(statusResult.response);
 
     // If response is stable and has content, override status to completed
-    if (isStable && statusResult.response.length > 50 && !statusResult.hasStopButton) {
+    if (isStable && statusResult.response.length > 8 && !statusResult.hasStopButton) {
       statusResult.status = 'completed';
     }
 

--- a/src/comet-ai.ts
+++ b/src/comet-ai.ts
@@ -216,11 +216,10 @@ export class CometAI {
 
     // For contenteditable: use CDP insertText for proper React state sync
     if (typed.needsCdpInsert) {
-      await new Promise(resolve => setTimeout(resolve, 200));
       await cometClient.insertText(prompt);
-      await new Promise(resolve => setTimeout(resolve, 500));
+      await new Promise(resolve => setTimeout(resolve, 200));
     } else {
-      await new Promise(resolve => setTimeout(resolve, 400));
+      await new Promise(resolve => setTimeout(resolve, 200));
     }
 
     const inputState = await this.getInputContentState(inputSelector);
@@ -240,7 +239,7 @@ export class CometAI {
    * Submit the current prompt
    */
   private async submitPrompt(inputSelector: string): Promise<void> {
-    await new Promise(resolve => setTimeout(resolve, 500));
+    await new Promise(resolve => setTimeout(resolve, 200));
 
     const hasContent = await this.verifyInputHasContent(inputSelector);
     if (!hasContent) {
@@ -258,106 +257,51 @@ export class CometAI {
 
     let submitMethod = '';
 
-    if (contentEditableSubmit.result.value === true) {
-      // Dismiss any autocomplete/suggestion overlays that consume Enter
-      await cometClient.pressKey('Escape');
-      await new Promise(resolve => setTimeout(resolve, 300));
-      // Re-focus the input after Escape
+    // Strategy 1: Click the submit button directly (fastest, most reliable)
+    const submitButton = await this.detectSubmitButton(inputSelector);
+    if (submitButton.selector) {
       await cometClient.evaluate(`
         (() => {
-          const el = document.querySelector(${JSON.stringify(inputSelector)});
-          if (el) el.focus();
-        })()
-      `);
-      await new Promise(resolve => setTimeout(resolve, 200));
-
-      await cometClient.pressKey('Enter');
-      await new Promise(resolve => setTimeout(resolve, 900));
-      const inputStateAfterEnter = await this.getInputContentState(inputSelector);
-      if (inputStateAfterEnter.value.length === 0 || await this.isPromptSubmitted(inputSelector)) {
-        submitMethod = 'cdp-enter-key';
-      }
-    } else {
-      await cometClient.evaluate(`
-        (() => {
-          const el = document.querySelector(${JSON.stringify(inputSelector)});
-          if (!el) return false;
-
-          el.focus();
-
-          const form = el.closest('form');
-          if (form && typeof form.requestSubmit === 'function') {
-            form.requestSubmit();
-            return true;
-          }
-
+          const btn = document.querySelector(${JSON.stringify(submitButton.selector)});
+          if (btn && !btn.disabled) { btn.click(); return true; }
           return false;
         })()
       `);
-
-      await new Promise(resolve => setTimeout(resolve, 700));
-      const inputStateAfterPrimaryAttempt = await this.getInputContentState(inputSelector);
-      if (inputStateAfterPrimaryAttempt.value.length === 0 || await this.isPromptSubmitted(inputSelector)) {
-        submitMethod = 'selected-input-submit';
+      await new Promise(resolve => setTimeout(resolve, 400));
+      if (await this.isPromptSubmitted(inputSelector)) {
+        submitMethod = `click-${submitButton.method || 'button'}`;
       }
     }
 
-    if (!submitMethod) {
+    // Strategy 2: Escape autocomplete + Enter key
+    if (!submitMethod && contentEditableSubmit.result.value === true) {
+      await cometClient.pressKey('Escape');
+      await new Promise(resolve => setTimeout(resolve, 150));
       await cometClient.evaluate(`
-        (() => {
-          const el = document.querySelector(${JSON.stringify(inputSelector)});
-          if (el) el.focus();
-          return true;
-        })()
+        (() => { const el = document.querySelector(${JSON.stringify(inputSelector)}); if (el) el.focus(); })()
       `);
+      await new Promise(resolve => setTimeout(resolve, 100));
       await cometClient.pressKey('Enter');
-      await new Promise(resolve => setTimeout(resolve, 900));
+      await new Promise(resolve => setTimeout(resolve, 500));
       if (await this.isPromptSubmitted(inputSelector)) {
         submitMethod = 'cdp-enter-key';
       }
     }
 
-    if (!submitMethod) {
-      const submitButton = await this.detectSubmitButton(inputSelector);
-      if (submitButton.selector) {
-        await cometClient.evaluate(`
-          (() => {
-            const btn = document.querySelector(${JSON.stringify(submitButton.selector)});
-            if (btn && !btn.disabled) {
-              btn.click();
-              return true;
-            }
-            return false;
-          })()
-        `);
-        await new Promise(resolve => setTimeout(resolve, 800));
-        if (await this.isPromptSubmitted(inputSelector)) {
-          submitMethod = `click-${submitButton.method || 'button'}`;
-        }
-      }
-    }
-
+    // Strategy 3: Form submit
     if (!submitMethod) {
       await cometClient.evaluate(`
         (() => {
           const el = document.querySelector(${JSON.stringify(inputSelector)});
           const form = el?.closest('form') || document.querySelector('form');
-          if (!form) {
-            return false;
-          }
-
-          if (typeof form.requestSubmit === 'function') {
-            form.requestSubmit();
-            return true;
-          }
-
-          form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
-          return true;
+          if (form && typeof form.requestSubmit === 'function') { form.requestSubmit(); return true; }
+          if (form) { form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true })); return true; }
+          return false;
         })()
       `);
-      await new Promise(resolve => setTimeout(resolve, 800));
+      await new Promise(resolve => setTimeout(resolve, 400));
       if (await this.isPromptSubmitted(inputSelector)) {
-        submitMethod = 'form-submit-fallback';
+        submitMethod = 'form-submit';
       }
     }
 
@@ -371,13 +315,13 @@ export class CometAI {
   // Track response stability for completion detection
   private lastResponseText: string = '';
   private stableResponseCount: number = 0;
-  private readonly STABILITY_THRESHOLD: number = 2; // Response must be same for 2 checks
+  private readonly STABILITY_THRESHOLD: number = 2; // Response must be same for 2 consecutive polls
 
   /**
    * Check if response has stabilized (same content for multiple polls)
    */
   isResponseStable(currentResponse: string): boolean {
-    if (currentResponse && currentResponse.length > 50) {
+    if (currentResponse && currentResponse.length > 8) {
       if (currentResponse === this.lastResponseText) {
         this.stableResponseCount++;
       } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -284,8 +284,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         let sawNewResponse = false;
         let lastActivityTime = Date.now();
         let previousResponse = '';
-        const POLL_INTERVAL = 1500;
-        const IDLE_TIMEOUT = 6000;
+        const POLL_INTERVAL = 500;
+        const IDLE_TIMEOUT = 2000;
         let consecutiveErrors = 0;
         const MAX_CONSECUTIVE_ERRORS = 5;
 
@@ -682,14 +682,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                 return { success: false, error: "Mode option not found in dropdown", visibleOptions: visibleLinks.slice(0, 15).join(', ') };
               })()
             `));
-            const selectRes = selectResult.result.value as { success: boolean; error?: string; matched?: string; candidateCount?: number };
+            const selectRes = selectResult.result.value as { success: boolean; error?: string; matched?: string; visibleOptions?: string };
             if (selectRes.success) {
               return { content: [{ type: "text", text: `Switched to ${mode} mode` }] };
             }
             if (attempt < 2) {
               await new Promise(resolve => setTimeout(resolve, 400));
             } else {
-              return { content: [{ type: "text", text: `Failed: ${selectRes.error} (${selectRes.candidateCount} visible items checked)` }], isError: true };
+              return { content: [{ type: "text", text: `Failed: ${selectRes.error}${selectRes.visibleOptions ? ` (visible: ${selectRes.visibleOptions})` : ''}` }], isError: true };
             }
           }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@ import {
 import { cometClient } from "./cdp-client.js";
 import { cometAI } from "./comet-ai.js";
 
-// Session state for tracking task progress and preventing stale responses
 interface SessionState {
   currentTaskId: string | null;
   taskStartTime: number | null;
@@ -35,12 +34,10 @@ const sessionState: SessionState = {
   isActive: false,
 };
 
-// Helper to generate task ID
 function generateTaskId(): string {
   return `task_${Date.now()}_${Math.random().toString(36).substring(2, 8)}`;
 }
 
-// Helper to reset session for new task
 function startNewTask(prompt: string): string {
   const taskId = generateTaskId();
   sessionState.currentTaskId = taskId;
@@ -54,17 +51,14 @@ function startNewTask(prompt: string): string {
   return taskId;
 }
 
-// Helper to complete task
 function completeTask(response: string): void {
   sessionState.lastResponse = response;
   sessionState.lastResponseTime = Date.now();
   sessionState.isActive = false;
 }
 
-// Helper to check if session is stale
 function isSessionStale(): boolean {
   if (!sessionState.taskStartTime) return true;
-  // Consider session stale if no activity for 5 minutes
   return Date.now() - sessionState.taskStartTime > 5 * 60 * 1000;
 }
 
@@ -176,151 +170,101 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   try {
     switch (name) {
       case "comet_connect": {
-        // Auto-start Comet with debug port (will restart if running without it)
-        const startResult = await cometClient.startComet(9223);
+        const requestedAutomationConfig = cometClient.getAutomationConfig();
+        const startResult = await cometClient.startComet(requestedAutomationConfig.port);
+        const activeAutomationConfig = cometClient.getAutomationConfig();
+        const mainTab = await cometClient.connectToAutomationMainTab();
+        cometClient.setAutomationMainTabId(mainTab.id);
 
-        // Get all tabs - DON'T clean up tabs, as closing them can crash Comet
-        const targets = await cometClient.listTargets();
-        const freshTargets = targets; // Use the same list, no cleanup
+        console.error(`[comet] Connected automation session mode=${activeAutomationConfig.profileMode} port=${activeAutomationConfig.port} profile=${activeAutomationConfig.profileDir} userDataDir=${activeAutomationConfig.userDataDir} controlTab=${mainTab.id}`);
 
-        // Prefer connecting to existing Perplexity tab, or any page tab
-        const perplexityTab = freshTargets.find(t => t.type === 'page' && t.url.includes('perplexity.ai'));
-        const anyPage = perplexityTab || freshTargets.find(t => t.type === 'page');
-
-        if (anyPage) {
-          await cometClient.connect(anyPage.id);
-
-          // Only navigate to Perplexity if not already there
-          if (!anyPage.url.includes('perplexity.ai')) {
-            await cometClient.navigate("https://www.perplexity.ai/", true);
-            await new Promise(resolve => setTimeout(resolve, 1500));
-          }
-
-          return { content: [{ type: "text", text: `${startResult}\nConnected to Perplexity` }] };
-        }
-
-        // No tabs at all - create a new one
-        const newTab = await cometClient.newTab("https://www.perplexity.ai/");
-        await new Promise(resolve => setTimeout(resolve, 2000)); // Wait for page load
-        await cometClient.connect(newTab.id);
-        return { content: [{ type: "text", text: `${startResult}\nCreated new tab and navigated to Perplexity` }] };
+        return {
+          content: [{
+            type: "text",
+            text: `${startResult}\nConnected automation session mode=${activeAutomationConfig.profileMode} profile=${activeAutomationConfig.profileDir} userDataDir=${activeAutomationConfig.userDataDir} with Perplexity control tab (${mainTab.id})`
+          }]
+        };
       }
 
       case "comet_ask": {
         let prompt = args?.prompt as string;
         const context = args?.context as string | undefined;
-        const maxTimeout = (args?.timeout as number) || 120000; // Max 2 minutes safety net
+        const maxTimeout = (args?.timeout as number) || 120000;
         const newChat = (args?.newChat as boolean) || false;
 
-        // Validate prompt
         if (!prompt || prompt.trim().length === 0) {
           return { content: [{ type: "text", text: "Error: prompt cannot be empty" }] };
         }
 
-        // If context is provided, prepend it to the prompt
         if (context && context.trim().length > 0) {
-          // Format context as a clear prefix
           const contextPrefix = `Context for this task:\n\`\`\`\n${context.trim()}\n\`\`\`\n\nBased on the above context, `;
           prompt = contextPrefix + prompt;
         }
 
-        // Start new task session - resets state and prevents stale poll responses
-        const taskId = startNewTask(prompt);
+        startNewTask(prompt);
 
-        // CRITICAL: Pre-operation connection check for one-shot reliability
         try {
           await cometClient.preOperationCheck();
-        } catch (preCheckError) {
-          // If pre-check fails, try to recover
+          await cometClient.connectToAutomationMainTab();
+        } catch {
           try {
-            await cometClient.startComet(9223);
-            const targets = await cometClient.listTargets();
-            const page = targets.find(t => t.type === 'page');
-            if (page) await cometClient.connect(page.id);
+            await cometClient.startComet(cometClient.getAutomationConfig().port);
+            await cometClient.connectToAutomationMainTab();
           } catch {
             return { content: [{ type: "text", text: "Error: Failed to establish connection to Comet browser" }] };
           }
         }
 
-        // Normalize prompt - convert markdown/bullets to natural text
         prompt = prompt
-          .replace(/^[-*•]\s*/gm, '')  // Remove bullet points
-          .replace(/\n+/g, ' ')         // Collapse newlines to spaces
-          .replace(/\s+/g, ' ')         // Collapse multiple spaces
+          .replace(/^[-*•]\s*/gm, '')
+          .replace(/\n+/g, ' ')
+          .replace(/\s+/g, ' ')
           .trim();
 
-        // Transform prompt to trigger agentic browsing when needed
-        // Detect if prompt requires browser actions (URLs, action verbs, website references)
+        // Only add agentic browsing prefix when the prompt contains an explicit URL.
+        // Common words like "check", "read", "open" in regular prompts should NOT
+        // trigger the browsing transform — Perplexity handles agentic browsing on its own.
         const hasUrl = /https?:\/\/[^\s]+/.test(prompt);
-        const hasWebsiteRef = /\b(go to|visit|navigate|open|browse|check|look at|read from|click|fill|submit|login|sign in|download from)\b/i.test(prompt);
-        const hasSiteNames = /\b(\.com|\.org|\.io|\.net|\.ai|website|webpage|page|site)\b/i.test(prompt);
-        const needsAgenticBrowsing = hasUrl || hasWebsiteRef || hasSiteNames;
-
-        // If prompt needs browser action but doesn't have agentic language, add it
-        if (needsAgenticBrowsing) {
+        if (hasUrl) {
           const alreadyAgentic = /^(use your browser|using your browser|open a browser|navigate to|browse to)/i.test(prompt);
           if (!alreadyAgentic) {
-            // Transform to agentic prompt
-            if (hasUrl) {
-              // Extract URL and restructure prompt
-              const urlMatch = prompt.match(/https?:\/\/[^\s]+/);
-              if (urlMatch) {
-                const url = urlMatch[0];
-                const restOfPrompt = prompt.replace(url, '').trim();
-                prompt = `Use your browser to navigate to ${url} and ${restOfPrompt || 'tell me what you find there'}`;
-              }
-            } else {
-              // Add agentic prefix for site references
-              prompt = `Use your browser to ${prompt.toLowerCase().startsWith('go') ? '' : 'go and '}${prompt}`;
+            const urlMatch = prompt.match(/https?:\/\/[^\s]+/);
+            if (urlMatch) {
+              const url = urlMatch[0];
+              const restOfPrompt = prompt.replace(url, '').trim();
+              prompt = `Use your browser to navigate to ${url} and ${restOfPrompt || 'tell me what you find there'}`;
             }
           }
         }
 
-        // For newChat: navigate to fresh Perplexity home (don't aggressively close tabs)
-        if (newChat) {
-          // Ensure we're connected
-          await cometClient.ensureConnection();
+        await cometClient.connectToAutomationMainTab();
 
-          // Just navigate to Perplexity home for a fresh start
-          try {
-            await cometClient.navigate("https://www.perplexity.ai/", true);
-            await new Promise(resolve => setTimeout(resolve, 2000));
-          } catch (navError) {
-            // If navigation fails, try to reconnect and retry
-            const targets = await cometClient.listTargets();
-            const mainTab = targets.find(t => t.type === 'page' && t.url.includes('perplexity'));
-            if (mainTab) {
-              await cometClient.connect(mainTab.id);
-            } else {
-              const anyPage = targets.find(t => t.type === 'page');
-              if (anyPage) {
-                await cometClient.connect(anyPage.id);
-                await cometClient.navigate("https://www.perplexity.ai/", true);
-              }
-            }
-            await new Promise(resolve => setTimeout(resolve, 1500));
-          }
+        if (newChat) {
+          await cometClient.ensureConnection();
+          const mainTab = await cometClient.connectToAutomationMainTab();
+          cometClient.setAutomationMainTabId(mainTab.id);
+          await cometClient.navigate("https://www.perplexity.ai/", true);
+          await new Promise(resolve => setTimeout(resolve, 2200));
         } else {
-          // Not newChat - just ensure we're on Perplexity
-          const tabs = await cometClient.listTabsCategorized();
-          if (tabs.main) {
-            await cometClient.connect(tabs.main.id);
-          }
+          const mainTab = await cometClient.connectToAutomationMainTab();
+          cometClient.setAutomationMainTabId(mainTab.id);
 
           const urlResult = await cometClient.evaluate('window.location.href');
           const currentUrl = urlResult.result.value as string;
-          const isOnPerplexity = currentUrl?.includes('perplexity.ai');
-
-          if (!isOnPerplexity) {
+          if (!currentUrl?.includes('perplexity.ai')) {
             await cometClient.navigate("https://www.perplexity.ai/", true);
             await new Promise(resolve => setTimeout(resolve, 2000));
           }
         }
 
-        // Reset stability tracking for new prompt
+        const askAutomationConfig = cometClient.getAutomationConfig();
+        console.error(`[comet] Ask using automation controlTab=${cometClient.getAutomationMainTabId() || 'unknown'} port=${askAutomationConfig.port} profile=${askAutomationConfig.profileDir}`);
+
         cometAI.resetStabilityTracking();
 
-        // Capture old response state BEFORE sending prompt (for follow-up detection)
+        const oldUrlResult = await cometClient.evaluate('window.location.href');
+        const oldUrl = (oldUrlResult.result.value as string) || '';
+
         const oldStateResult = await cometClient.evaluate(`
           (() => {
             const proseEls = document.querySelectorAll('[class*="prose"]');
@@ -333,17 +277,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         `);
         const oldState = oldStateResult.result.value as { count: number; lastText: string };
 
-        // Send the prompt
         await cometAI.sendPrompt(prompt);
 
-        // Smart polling - detect completion based on activity, not fixed timeout
         const startTime = Date.now();
         const stepsCollected: string[] = [];
         let sawNewResponse = false;
         let lastActivityTime = Date.now();
         let previousResponse = '';
-        const POLL_INTERVAL = 1500; // Poll every 1.5 seconds for balance
-        const IDLE_TIMEOUT = 6000; // If no activity for 6s and we have a response, consider done
+        const POLL_INTERVAL = 1500;
+        const IDLE_TIMEOUT = 6000;
         let consecutiveErrors = 0;
         const MAX_CONSECUTIVE_ERRORS = 5;
 
@@ -351,122 +293,109 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL));
 
           try {
-            // CRITICAL: Ensure we're on Perplexity tab during agentic browsing
-            // Comet may have opened new tabs which can break our connection
-            const isOnPerplexity = await cometClient.isOnPerplexityTab();
-            if (!isOnPerplexity) {
-              const switched = await cometClient.ensureOnPerplexityTab();
-              if (!switched) {
-                consecutiveErrors++;
-                continue; // Try again next poll
-              }
-            }
+            const status = await cometClient.withAutomationMainTab(async () => {
+              const currentStateResult = await cometClient.withAutoReconnect(async () => {
+                return await cometClient.evaluate(`
+                  (() => {
+                    const proseEls = document.querySelectorAll('[class*="prose"]');
+                    const lastProse = proseEls[proseEls.length - 1];
+                    return {
+                      count: proseEls.length,
+                      lastText: lastProse ? lastProse.innerText.substring(0, 100) : ''
+                    };
+                  })()
+                `);
+              });
+              const currentState = currentStateResult.result.value as { count: number; lastText: string };
 
-            // Check if we have a NEW response (more prose elements or different text)
-            const currentStateResult = await cometClient.withAutoReconnect(async () => {
-              return await cometClient.evaluate(`
-                (() => {
-                  const proseEls = document.querySelectorAll('[class*="prose"]');
-                  const lastProse = proseEls[proseEls.length - 1];
-                  return {
-                    count: proseEls.length,
-                    lastText: lastProse ? lastProse.innerText.substring(0, 100) : ''
-                  };
-                })()
-              `);
+              if (!sawNewResponse) {
+                // Check URL change (most reliable signal — home → search results)
+                try {
+                  const curUrlResult = await cometClient.evaluate('window.location.href');
+                  const curUrl = (curUrlResult.result.value as string) || '';
+                  if (curUrl !== oldUrl && curUrl.includes('/search/')) {
+                    sawNewResponse = true;
+                  }
+                } catch { /* continue with prose check */ }
+
+                // Also check prose element changes
+                if (currentState.count > oldState.count ||
+                    (currentState.lastText && currentState.lastText !== oldState.lastText)) {
+                  sawNewResponse = true;
+                }
+              }
+
+              return await cometAI.getAgentStatus();
             });
-            const currentState = currentStateResult.result.value as { count: number; lastText: string };
 
-            // Detect new response
-            if (!sawNewResponse) {
-              if (currentState.count > oldState.count ||
-                  (currentState.lastText && currentState.lastText !== oldState.lastText)) {
-                sawNewResponse = true;
-              }
-            }
+            consecutiveErrors = 0;
 
-            const status = await cometAI.getAgentStatus();
-            consecutiveErrors = 0; // Reset error count on success
-
-            // Track activity - if response changed, update activity time
             if (status.response !== previousResponse) {
               lastActivityTime = Date.now();
               previousResponse = status.response;
             }
 
-            // Collect steps
             for (const step of status.steps) {
               if (!stepsCollected.includes(step)) {
                 stepsCollected.push(step);
-                lastActivityTime = Date.now(); // New step = activity
+                lastActivityTime = Date.now();
               }
             }
 
-            // Track steps in session state
             sessionState.steps = stepsCollected;
 
-            // COMPLETION CONDITIONS (return immediately when any are met):
-
-            // 1. Explicit completion detected by status checker
             if (status.status === 'completed' && sawNewResponse && status.response) {
               completeTask(status.response);
               return { content: [{ type: "text", text: status.response }] };
             }
 
-            // 2. Response is stable (same content for 2+ polls) and no stop button
             if (status.isStable && sawNewResponse && status.response && !status.hasStopButton) {
               completeTask(status.response);
               return { content: [{ type: "text", text: status.response }] };
             }
 
-            // 3. Idle timeout - no activity for 6s but we have a substantial response
             const idleTime = Date.now() - lastActivityTime;
-            if (idleTime > IDLE_TIMEOUT && sawNewResponse && status.response &&
-                status.response.length > 100 && !status.hasStopButton) {
+            if (idleTime > IDLE_TIMEOUT && sawNewResponse && status.response && status.response.length > 10 && !status.hasStopButton) {
               completeTask(status.response);
               return { content: [{ type: "text", text: status.response }] };
             }
-          } catch (pollError) {
+          } catch {
             consecutiveErrors++;
 
-            // Try to recover by switching to Perplexity tab
             try {
-              const recovered = await cometClient.ensureOnPerplexityTab();
-              if (recovered) {
-                consecutiveErrors = Math.max(0, consecutiveErrors - 1);
-                continue;
-              }
+              await cometClient.connectToAutomationMainTab();
+              consecutiveErrors = Math.max(0, consecutiveErrors - 1);
+              continue;
             } catch {
-              // Continue to fallback
+              // Continue to fallback recovery.
             }
 
             if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
-              // Too many errors, try harder to recover
               try {
                 await cometClient.ensureConnection();
-                await cometClient.ensureOnPerplexityTab();
+                await cometClient.connectToAutomationMainTab();
                 consecutiveErrors = 0;
               } catch {
-                // If still failing, exit loop and return partial result
                 break;
               }
             }
-            // Continue polling despite temporary errors
-            continue;
           }
         }
 
-        // Max timeout reached - return whatever we have
-        const finalStatus = await cometAI.getAgentStatus();
-        if (finalStatus.response && finalStatus.response.length > 50) {
+        let finalStatus;
+        try {
+          finalStatus = await cometClient.withAutomationMainTab(async () => cometAI.getAgentStatus());
+        } catch {
+          // Status check failed — fall through to timeout message
+        }
+        if (finalStatus?.response && finalStatus.response.length > 0) {
           completeTask(finalStatus.response);
           return { content: [{ type: "text", text: finalStatus.response }] };
         }
 
-        // No response - return progress info (task still active)
         let inProgressMsg = `Task may still be in progress (max timeout reached).\n`;
-        inProgressMsg += `Status: ${finalStatus.status.toUpperCase()}\n`;
-        if (finalStatus.currentStep) {
+        inProgressMsg += `Status: ${finalStatus?.status?.toUpperCase() || 'UNKNOWN'}\n`;
+        if (finalStatus?.currentStep) {
           inProgressMsg += `Current: ${finalStatus.currentStep}\n`;
         }
         if (stepsCollected.length > 0) {
@@ -474,23 +403,19 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
         inProgressMsg += `\nUse comet_poll to check progress or comet_stop to cancel.`;
 
-        // Keep task active since it may still be running
         sessionState.steps = stepsCollected;
         return { content: [{ type: "text", text: inProgressMsg }] };
       }
 
       case "comet_poll": {
-        // Check if there's an active task session
         if (!sessionState.isActive && !sessionState.currentTaskId) {
           return { content: [{ type: "text", text: "Status: IDLE\nNo active task. Use comet_ask to start a new task." }] };
         }
 
-        // Check for stale session (no activity for 5+ minutes)
         if (isSessionStale() && !sessionState.isActive) {
           return { content: [{ type: "text", text: "Status: IDLE\nPrevious task session expired. Use comet_ask to start a new task." }] };
         }
 
-        // If task was already completed, return the cached response
         if (!sessionState.isActive && sessionState.lastResponse) {
           const timeSinceComplete = sessionState.lastResponseTime
             ? Math.round((Date.now() - sessionState.lastResponseTime) / 1000)
@@ -498,31 +423,24 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           return { content: [{ type: "text", text: `Status: COMPLETED (${timeSinceComplete}s ago)\n\n${sessionState.lastResponse}` }] };
         }
 
-        // Active task - get fresh status from Perplexity
-        await cometClient.ensureOnPerplexityTab();
-        const status = await cometAI.getAgentStatus();
+        const status = await cometClient.withAutomationMainTab(async () => cometAI.getAgentStatus());
 
-        // If completed, update session state and return response
         if (status.status === 'completed' && status.response) {
           completeTask(status.response);
           return { content: [{ type: "text", text: status.response }] };
         }
 
-        // Still working - return progress info
         let output = `Status: ${status.status.toUpperCase()}\n`;
         if (sessionState.currentTaskId) {
           output += `Task: ${sessionState.currentTaskId}\n`;
         }
-
         if (status.agentBrowsingUrl) {
           output += `Browsing: ${status.agentBrowsingUrl}\n`;
         }
-
         if (status.currentStep) {
           output += `Current: ${status.currentStep}\n`;
         }
 
-        // Combine session steps with current status steps
         const allSteps = [...new Set([...sessionState.steps, ...status.steps])];
         if (allSteps.length > 0) {
           output += `\nSteps:\n${allSteps.map(s => `  • ${s}`).join('\n')}\n`;
@@ -536,7 +454,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "comet_stop": {
-        const stopped = await cometAI.stopAgent();
+        const stopped = await cometClient.withAutomationMainTab(async () => cometAI.stopAgent());
         if (stopped) {
           sessionState.isActive = false;
         }
@@ -583,29 +501,32 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           }
 
           case 'close': {
-            // Safety check: don't close if it would leave no browsing tabs
-            const allTabs = await cometClient.getTabContexts();
-
-            // allTabs now only contains external tabs (Perplexity is filtered as internal)
-            if (allTabs.length <= 1) {
-              return { content: [{ type: "text", text: "Cannot close - this is the only browsing tab. Comet needs at least one external tab open." }], isError: true };
-            }
-
             if (tabId) {
-              const success = await cometClient.closeTab(tabId);
+              if (await cometClient.isAutomationMainTab(tabId)) {
+                return { content: [{ type: "text", text: "Cannot close the Perplexity control tab" }], isError: true };
+              }
+
+              const closableCount = await cometClient.getClosableTabCount();
+              if (closableCount <= 0) {
+                return { content: [{ type: "text", text: "Cannot close - no closable browsing tabs are open." }], isError: true };
+              }
+
+              const success = await cometClient.closeTrackedTab(tabId);
               return { content: [{ type: "text", text: success ? `Closed tab: ${tabId}` : `Failed to close tab` }] };
             }
+
             if (domain) {
               const tab = await cometClient.findTabByDomain(domain);
               if (tab && tab.purpose !== 'main') {
-                const success = await cometClient.closeTab(tab.id);
+                const success = await cometClient.closeTrackedTab(tab.id);
                 return { content: [{ type: "text", text: success ? `Closed ${tab.domain}` : `Failed to close tab` }] };
               }
               if (tab?.purpose === 'main') {
-                return { content: [{ type: "text", text: "Cannot close main Perplexity tab" }], isError: true };
+                return { content: [{ type: "text", text: "Cannot close the Perplexity control tab" }], isError: true };
               }
               return { content: [{ type: "text", text: `No tab found for domain: ${domain}` }], isError: true };
             }
+
             return { content: [{ type: "text", text: "Specify domain or tabId to close" }], isError: true };
           }
 
@@ -617,11 +538,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case "comet_mode": {
         const mode = args?.mode as string | undefined;
 
-        // If no mode provided, show current mode
         if (!mode) {
-          const result = await cometClient.evaluate(`
+          const result = await cometClient.withAutomationMainTab(async () => cometClient.evaluate(`
             (() => {
-              // Try button group first (wide screen)
               const modes = ['Search', 'Research', 'Labs', 'Learn'];
               for (const mode of modes) {
                 const btn = document.querySelector('button[aria-label="' + mode + '"]');
@@ -629,7 +548,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                   return mode.toLowerCase();
                 }
               }
-              // Try dropdown (narrow screen) - look for the mode selector button
               const dropdownBtn = document.querySelector('button[class*="gap"]');
               if (dropdownBtn) {
                 const text = dropdownBtn.innerText.toLowerCase();
@@ -640,7 +558,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               }
               return 'search';
             })()
-          `);
+          `));
 
           const currentMode = result.result.value as string;
           const descriptions: Record<string, string> = {
@@ -659,7 +577,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           return { content: [{ type: "text", text: output }] };
         }
 
-        // Switch mode
         const modeMap: Record<string, string> = {
           search: "Search",
           research: "Research",
@@ -674,73 +591,117 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           };
         }
 
-        // Navigate to Perplexity first if not there
-        const state = cometClient.currentState;
-        if (!state.currentUrl?.includes("perplexity.ai")) {
-          await cometClient.navigate("https://www.perplexity.ai/", true);
-        }
+        // Navigate to home page for mode switching (modes are on the main search page)
+        await cometClient.withAutomationMainTab(async () => {
+          const state = cometClient.currentState;
+          if (!state.currentUrl || !state.currentUrl.match(/perplexity\.ai\/?$/)) {
+            await cometClient.navigate("https://www.perplexity.ai/", true);
+            await new Promise(resolve => setTimeout(resolve, 1500));
+          }
+        });
 
-        // Try both UI patterns: button group (wide) and dropdown (narrow)
-        const result = await cometClient.evaluate(`
-          (() => {
-            // Strategy 1: Direct button (wide screen)
-            const btn = document.querySelector('button[aria-label="${ariaLabel}"]');
-            if (btn) {
-              btn.click();
-              return { success: true, method: 'button' };
-            }
-
-            // Strategy 2: Dropdown menu (narrow screen)
-            // Find and click the dropdown trigger (button with current mode text)
-            const allButtons = document.querySelectorAll('button');
-            for (const b of allButtons) {
-              const text = b.innerText.toLowerCase();
-              if ((text.includes('search') || text.includes('research') ||
-                   text.includes('labs') || text.includes('learn')) &&
-                  b.querySelector('svg')) {
-                b.click();
-                return { success: true, method: 'dropdown-open', needsSelect: true };
+        const result = await cometClient.withAutomationMainTab(async () => {
+          return cometClient.evaluate(`
+            (() => {
+              // Try direct aria-label buttons first (old UI)
+              const directBtn = document.querySelector('button[aria-label="${ariaLabel}"]');
+              if (directBtn) {
+                directBtn.click();
+                return { success: true, method: 'direct-button' };
               }
-            }
 
-            return { success: false, error: "Mode selector not found" };
-          })()
-        `);
+              // Try finding any button that could open a mode/model menu
+              const menuButton = [...document.querySelectorAll('button')].find(btn => {
+                const aria = (btn.getAttribute('aria-label') || '').toLowerCase();
+                const text = (btn.innerText || '').trim().toLowerCase();
+                return aria === 'model' || text === 'model' ||
+                       aria.includes('search mode') || aria.includes('focus') ||
+                       text === 'search' || text === 'research' || text === 'labs' || text === 'learn';
+              });
+
+              if (menuButton) {
+                // If this button IS the desired mode, just click it
+                const btnText = (menuButton.innerText || '').trim().toLowerCase();
+                if (btnText === '${mode}'.toLowerCase()) {
+                  menuButton.click();
+                  return { success: true, method: 'direct-mode-button' };
+                }
+                menuButton.click();
+                return { success: true, method: 'model-menu', needsSelect: true };
+              }
+
+              return { success: false, error: "Mode selector not found on page. Navigate to perplexity.ai first." };
+            })()
+          `);
+        });
 
         const clickResult = result.result.value as { success: boolean; method?: string; needsSelect?: boolean; error?: string };
 
         if (clickResult.success && clickResult.needsSelect) {
-          // Wait for dropdown to open, then select the mode
-          await new Promise(resolve => setTimeout(resolve, 300));
-          const selectResult = await cometClient.evaluate(`
-            (() => {
-              // Look for dropdown menu items
-              const items = document.querySelectorAll('[role="menuitem"], [role="option"], button');
-              for (const item of items) {
-                if (item.innerText.toLowerCase().includes('${mode}')) {
-                  item.click();
-                  return { success: true };
+          // Wait for dropdown/popover to render
+          await new Promise(resolve => setTimeout(resolve, 600));
+
+          // Try selecting the mode from the dropdown with retries
+          for (let attempt = 0; attempt < 3; attempt++) {
+            const selectResult = await cometClient.withAutomationMainTab(async () => cometClient.evaluate(`
+              (() => {
+                const desired = '${mode}'.toLowerCase();
+                // Search for clickable elements matching the desired mode
+                // Use leaf-node links/buttons first (most specific), then broaden
+                const selectors = ['a', 'button', '[role="menuitem"]', '[role="option"]', 'div[role="button"]', 'label'];
+                for (const sel of selectors) {
+                  const items = [...document.querySelectorAll(sel)];
+                  for (const item of items) {
+                    const text = (item.innerText || '').trim().toLowerCase();
+                    const aria = (item.getAttribute?.('aria-label') || '').trim().toLowerCase();
+                    const rect = item.getBoundingClientRect();
+                    const isVisible = rect.height > 0 && rect.width > 0;
+                    // Match: exact text match or text starts with desired mode
+                    if (isVisible && text.length < 40 && (text === desired || aria === desired)) {
+                      item.click();
+                      return { success: true, matched: text || aria };
+                    }
+                  }
                 }
-              }
-              return { success: false, error: "Mode option not found in dropdown" };
-            })()
-          `);
-          const selectRes = selectResult.result.value as { success: boolean; error?: string };
-          if (selectRes.success) {
-            return { content: [{ type: "text", text: `Switched to ${mode} mode` }] };
-          } else {
-            return { content: [{ type: "text", text: `Failed: ${selectRes.error}` }], isError: true };
+                // Fallback: partial match (text starts with desired)
+                for (const sel of selectors) {
+                  const items = [...document.querySelectorAll(sel)];
+                  for (const item of items) {
+                    const text = (item.innerText || '').trim().toLowerCase();
+                    const aria = (item.getAttribute?.('aria-label') || '').trim().toLowerCase();
+                    const rect = item.getBoundingClientRect();
+                    const isVisible = rect.height > 0 && rect.width > 0;
+                    if (isVisible && text.length < 40 && (text.startsWith(desired) || aria.startsWith(desired))) {
+                      item.click();
+                      return { success: true, matched: text || aria };
+                    }
+                  }
+                }
+                // Debug info
+                const visibleLinks = [...document.querySelectorAll('a, button')].filter(e => e.getBoundingClientRect().height > 0).map(e => e.innerText.trim().substring(0, 30)).filter(t => t.length > 0 && t.length < 30);
+                return { success: false, error: "Mode option not found in dropdown", visibleOptions: visibleLinks.slice(0, 15).join(', ') };
+              })()
+            `));
+            const selectRes = selectResult.result.value as { success: boolean; error?: string; matched?: string; candidateCount?: number };
+            if (selectRes.success) {
+              return { content: [{ type: "text", text: `Switched to ${mode} mode` }] };
+            }
+            if (attempt < 2) {
+              await new Promise(resolve => setTimeout(resolve, 400));
+            } else {
+              return { content: [{ type: "text", text: `Failed: ${selectRes.error} (${selectRes.candidateCount} visible items checked)` }], isError: true };
+            }
           }
         }
 
         if (clickResult.success) {
           return { content: [{ type: "text", text: `Switched to ${mode} mode` }] };
-        } else {
-          return {
-            content: [{ type: "text", text: `Failed to switch mode: ${clickResult.error}` }],
-            isError: true,
-          };
         }
+
+        return {
+          content: [{ type: "text", text: `Failed to switch mode: ${clickResult.error}` }],
+          isError: true,
+        };
       }
 
       case "comet_upload": {
@@ -752,13 +713,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           return { content: [{ type: "text", text: "Error: filePath is required" }], isError: true };
         }
 
-        // Check if file exists
         const fs = await import('fs');
         if (!fs.existsSync(filePath)) {
           return { content: [{ type: "text", text: `Error: File not found: ${filePath}` }], isError: true };
         }
 
-        // If checkOnly, just report what file inputs exist
         if (checkOnly) {
           const inputInfo = await cometClient.hasFileInput();
           if (inputInfo.found) {
@@ -766,29 +725,27 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             msg += inputInfo.selectors.map((s, i) => `  ${i + 1}. ${s}`).join('\n');
             msg += `\n\nUse comet_upload with filePath to upload to one of these inputs.`;
             return { content: [{ type: "text", text: msg }] };
-          } else {
-            return { content: [{ type: "text", text: "No file input elements found on the current page. Navigate to a page with a file upload form first." }] };
           }
+          return { content: [{ type: "text", text: "No file input elements found on the current page. Navigate to a page with a file upload form first." }] };
         }
 
-        // Perform the upload
         const result = await cometClient.uploadFile(filePath, selector);
 
         if (result.success) {
           return { content: [{ type: "text", text: result.message }] };
-        } else {
-          // If no input found, provide helpful info
-          if (!result.inputFound) {
-            const inputInfo = await cometClient.hasFileInput();
-            let msg = result.message;
-            if (inputInfo.found) {
-              msg += `\n\nAvailable file inputs:\n${inputInfo.selectors.map((s, i) => `  ${i + 1}. ${s}`).join('\n')}`;
-              msg += `\n\nTry specifying a selector parameter.`;
-            }
-            return { content: [{ type: "text", text: msg }], isError: true };
-          }
-          return { content: [{ type: "text", text: result.message }], isError: true };
         }
+
+        if (!result.inputFound) {
+          const inputInfo = await cometClient.hasFileInput();
+          let msg = result.message;
+          if (inputInfo.found) {
+            msg += `\n\nAvailable file inputs:\n${inputInfo.selectors.map((s, i) => `  ${i + 1}. ${s}`).join('\n')}`;
+            msg += `\n\nTry specifying a selector parameter.`;
+          }
+          return { content: [{ type: "text", text: msg }], isError: true };
+        }
+
+        return { content: [{ type: "text", text: result.message }], isError: true };
       }
 
       default:


### PR DESCRIPTION
## Summary

- Add `COMET_PROFILE_MODE=default` env var that reuses the user's logged-in Comet session
- Fix prompt submission to use CDP `insertText` for React compatibility
- Fix false-positive WORKING status from model names ("Claude Sonnet 4.6 Thinking")
- Remove aggressive auto-agentic prompt transform that triggered on common words
- Track baseline tabs so pre-existing user tabs aren't mislabeled as agent-browsing

## Test plan

- [x] All 8 MCP tools pass end-to-end (connect, ask, poll, stop, screenshot, tabs, mode, upload)
- [x] `comet_ask` reliably submits prompts and returns correct responses
- [x] Agent browsing with explicit URLs works
- [x] Pre-existing user tabs show as `TAB:` not `AGENT-BROWSING:`
- [x] No false-positive WORKING status from model names or unrelated UI elements

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)